### PR TITLE
chore: :wrench: Utilise la nouvelle fonctionnalité de VSCode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -62,11 +62,6 @@
     // https://github.com/vscode-icons/vscode-icons
     "vscode-icons-team.vscode-icons",
 
-    // A customizable extension for colorizing matching brackets
-    // https://github.com/CoenraadS/BracketPair
-    // (Archived, not maintained, but still working and the best...)
-    "coenraads.bracket-pair-colorizer",
-
     // Makes indentation easier to read
     // https://github.com/oderwat/vscode-indent-rainbow
     "oderwat.indent-rainbow",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "jest.jestCommandLine": "./node_modules/.bin/jest",
+  "editor.bracketPairColorization.enabled": true,
   "conventionalCommits.scopes": [
     "releases"
   ]


### PR DESCRIPTION
Permet de se passer de l'extension (et gagner en DX)
