### PR TITLE
docs: :memo: Ajoute lien vers exemple useScheme

### DIFF
--- a/src/stories/composables/composables.stories.mdx
+++ b/src/stories/composables/composables.stories.mdx
@@ -4,7 +4,9 @@ import { Meta } from '@storybook/addon-docs';
 
 # `useScheme`
 
-Ce composable permet de gérer simplement le thème du site :
+Ce composable permet de gérer simplement le thème du site. Vous trouverez ci-dessous des exemples d’utilisation.
+
+Un exemple complet est disponible sur [Stackblitz](https://stackblitz.com/edit/vue-dsfr-use-scheme?file=app.vue).
 
 ## Utilisation basique
 


### PR DESCRIPTION
Ajoute un lien vers un Stackblitz avec utilisation complète du composable Stackblitz
