### PR TITLE
fix([DsfrNavigationMenu]): :bug: Transmit toggle-id event to parent

### DIFF
--- a/src/components/DsfrNavigation/DsfrNavigationMenu.vue
+++ b/src/components/DsfrNavigation/DsfrNavigationMenu.vue
@@ -70,6 +70,7 @@ export default {
         <DsfrNavigationMenuLink
           v-bind="link"
           @click="link.onClick"
+          @toggle-id="$emit('toggle-id', expandedId)"
         />
       </DsfrNavigationMenuItem>
     </ul>


### PR DESCRIPTION
Transmid toggle-id event to parent so that the menu can be closed when navigate

Fix: #219