### PR TITLE
fix: :bug: Ajout de * si le champs est requis

### DIFF
--- a/src/components/DsfrInput/DsfrInput.vue
+++ b/src/components/DsfrInput/DsfrInput.vue
@@ -46,7 +46,7 @@ export default defineComponent({
     }"
     :for="id"
   >
-    {{ label }}
+    {{ label }} {{ $attrs.required ? '*' : '' }}
   </label>
   <component
     :is="isComponent"


### PR DESCRIPTION
Pour être en cohérence avec le DsfrSelect, ajout de * au label si le champ est obligatoire

Fix: #221