### PR TITLE
docs(DsfrFooter): :memo: Corrige la documentation de `operatorImgStyle`

### DIFF
--- a/src/components/DsfrFooter/DsfrFooter.stories.js
+++ b/src/components/DsfrFooter/DsfrFooter.stories.js
@@ -84,7 +84,7 @@ export default {
       description: 'URL pour un lien externe ou route ou objet pour un lien externe à associer au lien de l’image de l’opérateur',
     },
     operatorImgStyle: {
-      control: 'text',
+      control: 'object',
       description: 'Style supplémentaire pour l’image de l’opérateur',
     },
     operatorImgSrc: {

--- a/src/components/DsfrFooter/DsfrFooter.vue
+++ b/src/components/DsfrFooter/DsfrFooter.vue
@@ -110,7 +110,7 @@ export default defineComponent({
       default: '/',
     },
     operatorImgStyle: {
-      type: String,
+      type: Object,
       default: undefined,
     },
     operatorImgSrc: {


### PR DESCRIPTION
`operatorImgStyle` doit être un objet et non un texte.

#370 