### PR TITLE
Ajouter l'attribut `rel` avec la valeur `noreferrer noopener` pour les balises `<a>` qui ont un attribut `target`

### DIFF
--- a/src/components/DsfrAccordion/DsfrAccordion.e2e.js
+++ b/src/components/DsfrAccordion/DsfrAccordion.e2e.js
@@ -1,4 +1,4 @@
-import { mount } from '@cypress/vue'
+import { mount } from '@cypress/vue'
 import DsfrAccordion from './DsfrAccordion.vue'
 import DsfrAccordionsGroup from './DsfrAccordionsGroup.vue'
 import { OhVueIcon as VIcon } from 'oh-vue-icons'

--- a/src/components/DsfrFollow/DsfrFollow.e2e.js
+++ b/src/components/DsfrFollow/DsfrFollow.e2e.js
@@ -1,4 +1,4 @@
-import { mount } from '@cypress/vue'
+import { mount } from '@cypress/vue'
 import DsfrFollow from './DsfrFollow.vue'
 import { OhVueIcon as VIcon } from 'oh-vue-icons'
 import '../../main.css'

--- a/src/components/DsfrFollow/DsfrSocialNetworks.vue
+++ b/src/components/DsfrFollow/DsfrSocialNetworks.vue
@@ -39,6 +39,7 @@ export default defineComponent({
           :title="network.name"
           :href="network.href"
           target="_blank"
+          rel="noopener noreferrer"
         >
           {{ network.name }}
         </a>

--- a/src/components/DsfrFooter/DsfrFooter.vue
+++ b/src/components/DsfrFooter/DsfrFooter.vue
@@ -232,6 +232,7 @@ export default defineComponent({
               class="fr-link-licence  no-content-after"
               href="https://github.com/etalab/licence-ouverte/blob/master/LO.md"
               target="_blank"
+              rel="noopener noreferrer"
             >
               licence etalab-2.0
               <VIcon name="ri-external-link-line" />

--- a/src/components/DsfrFranceConnect/DsfrFranceConnect.vue
+++ b/src/components/DsfrFranceConnect/DsfrFranceConnect.vue
@@ -25,7 +25,7 @@ export default defineComponent({
       <a
         :href="secure ? 'https://franceconnect.gouv.fr/france-connect-plus' : 'https://franceconnect.gouv.fr/'"
         target="_blank"
-        rel="noopener"
+        rel="noopener noreferrer"
         :title="secure ? 'Qu’est ce que FranceConnect+ ? - nouvelle fenêtre' : 'Qu’est ce que FranceConnect ? - nouvelle fenêtre'"
       >Qu’est ce que FranceConnect{{ secure ? '+' : '' }} ?</a>
     </p>

--- a/src/components/DsfrHeader/DsfrHeader.e2e.js
+++ b/src/components/DsfrHeader/DsfrHeader.e2e.js
@@ -1,4 +1,4 @@
-import { mount } from '@cypress/vue'
+import { mount } from '@cypress/vue'
 import DsfrHeader from './DsfrHeader.vue'
 import '../../main.css'
 

--- a/src/components/DsfrHighlight/DsfrHighlight.e2e.js
+++ b/src/components/DsfrHighlight/DsfrHighlight.e2e.js
@@ -1,4 +1,4 @@
-import { mount } from '@cypress/vue'
+import { mount } from '@cypress/vue'
 import DsfrHighlight from './DsfrHighlight.vue'
 import '../../main.css'
 

--- a/src/components/DsfrInput/DsfrInput.e2e.js
+++ b/src/components/DsfrInput/DsfrInput.e2e.js
@@ -1,4 +1,4 @@
-import { mount } from '@cypress/vue'
+import { mount } from '@cypress/vue'
 import DsfrInput from './DsfrInput.vue'
 import '../../main.css'
 

--- a/src/components/DsfrLogo/DsfrLogo.e2e.js
+++ b/src/components/DsfrLogo/DsfrLogo.e2e.js
@@ -1,4 +1,4 @@
-import { mount } from '@cypress/vue'
+import { mount } from '@cypress/vue'
 import DsfrLogo from './DsfrLogo.vue'
 import '../../main.css'
 

--- a/src/components/DsfrMedia/DsfrMedia.e2e.js
+++ b/src/components/DsfrMedia/DsfrMedia.e2e.js
@@ -1,4 +1,4 @@
-import { mount } from '@cypress/vue'
+import { mount } from '@cypress/vue'
 import DsfrPicture from './DsfrPicture.vue'
 import DsfrVideo from './DsfrVideo.vue'
 import '../../main.css'

--- a/src/components/DsfrPagination/DsfrPagination.e2e.js
+++ b/src/components/DsfrPagination/DsfrPagination.e2e.js
@@ -1,4 +1,4 @@
-import { mount } from '@cypress/vue'
+import { mount } from '@cypress/vue'
 import DsfrPagination from './DsfrPagination.vue'
 import { OhVueIcon as VIcon } from 'oh-vue-icons'
 

--- a/src/components/DsfrQuote/DsfrQuote.vue
+++ b/src/components/DsfrQuote/DsfrQuote.vue
@@ -59,6 +59,7 @@ export default defineComponent({
           <a
             v-if="typeof detail === 'object'"
             target="_blank"
+            rel="noopener noreferrer"
             :href="detail.url"
           >
             {{ detail.label }}

--- a/src/components/DsfrSearchBar/DsfrSearchBar.vue
+++ b/src/components/DsfrSearchBar/DsfrSearchBar.vue
@@ -66,7 +66,7 @@ export default defineComponent({
       :model-value="modelValue"
       :label-visible="false"
       :label="label"
-      @update:modelValue="$emit('update:modelValue', $event)"
+      @update:model-value="$emit('update:modelValue', $event)"
       @keydown.enter="$emit('search')"
     />
     <DsfrButton

--- a/src/components/DsfrShare/DsfrShare.spec.js
+++ b/src/components/DsfrShare/DsfrShare.spec.js
@@ -42,7 +42,7 @@ describe('DsfrShare', () => {
     for (const network of networks) {
       const link = getByText(network.label)
       expect(link).toHaveAttribute('target', '_blank')
-      expect(link).toHaveAttribute('rel', 'noopener')
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer')
       expect(link).toHaveAttribute('title', `${network.label} - nouvelle fenêtre`)
     }
 

--- a/src/components/DsfrShare/DsfrShare.vue
+++ b/src/components/DsfrShare/DsfrShare.vue
@@ -40,7 +40,7 @@ export default defineComponent({
           :title="`${network.label} - nouvelle fenêtre`"
           :href="network.url"
           target="_blank"
-          rel="noopener"
+          rel="noopener noreferrer"
           @click.prevent="window.open(network.url, network.label, 'toolbar=no,location=yes,status=no,menubar=no,scrollbars=yes,resizable=yes,width=600,height=450')"
         >
           {{ network.label }}
@@ -52,6 +52,7 @@ export default defineComponent({
           :href="mail.to"
           :title="mail.label"
           target="_blank"
+          rel="noopener noreferrer"
         >
           {{ mail.label }}
         </a>

--- a/src/components/DsfrTabs/DsfrTabs.e2e.js
+++ b/src/components/DsfrTabs/DsfrTabs.e2e.js
@@ -1,4 +1,4 @@
-import { mount } from '@cypress/vue'
+import { mount } from '@cypress/vue'
 import DsfrTabs from './DsfrTabs.vue'
 import { OhVueIcon as VIcon } from 'oh-vue-icons'
 


### PR DESCRIPTION
- fix: :bug: Ajoute l'attribut rel="noopener noreferrer" aux balises <a> contenant un attribut "target"
- style: :art: Corrige les warnings remontées par le linter

#337 