### PR TITLE
fix: :bug: Add possibility to have undefined model-value

### DIFF
--- a/types/components/DsfrRadioButton/DsfrRadioButton.vue.d.ts
+++ b/types/components/DsfrRadioButton/DsfrRadioButton.vue.d.ts
@@ -64,7 +64,7 @@ declare const _default: import('vue').DefineComponent<{
     id: string;
     img: string;
     label: string;
-    modelValue: string | number;
+    modelValue: string | number | undefined;
     hint: string;
 }>
 export default _default


### PR DESCRIPTION
## Objet

Lorsqu'on veut initialiser une data à `undefined` en utilisant un composant du Dsfr, cela provoque un `warn` en console :
`[Vue warn]: Invalid prop: type check failed for prop "modelValue". Expected String | Number, got Undefined`

On a donc ajouté la possibilité d'avoir un type `undefined` dans le `DsfrRadioButton.vue.d.ts`.