### PR TITLE
fix: :bug: aria-current property of DsfrSideMenuButton

### DIFF
--- a/src/components/DsfrSideMenu/DsfrSideMenuButton.vue
+++ b/src/components/DsfrSideMenu/DsfrSideMenuButton.vue
@@ -14,7 +14,7 @@ defineEmits(['toggle-expand'])
 <template>
   <button
     class="fr-sidemenu__btn"
-    :aria-current="!!active"
+    :aria-current="active ? 'page' : undefined"
     :aria-expanded="!!expanded"
     :aria-controls="controlId"
     @click="$emit('toggle-expand', controlId)"


### PR DESCRIPTION
## BUG

Le `DsfrSideMenuButton` est toujours de style actif car :
- le style actif est appliqué sur `.fr-sidemenu__btn[aria-current]`
- la propriété `aria-current` du `DsfrSideMenuButton` est un booléen

## Proposition de fix

- retourner `page` ou `undefined` dans `aria-current` (comme dans `DsfrSideMenuLink`)
