### PR TITLE
fix(DsfrNavigation): :bug: Fermeture du menu si clic à l'extérieur et si touche Echap pressée

### DIFF
--- a/src/components/DsfrNavigation/DsfrNavigation.vue
+++ b/src/components/DsfrNavigation/DsfrNavigation.vue
@@ -40,7 +40,14 @@ export default defineComponent({
       expandedMenuId: undefined,
     }
   },
-
+  mounted () {
+    document.addEventListener('click', this.onDocumentClick)
+    document.addEventListener('keydown', this.onKeyDown)
+  },
+  unmounted () {
+    document.removeEventListener('click', this.onDocumentClick)
+    document.removeEventListener('keydown', this.onKeyDown)
+  },
   methods: {
     toggle (id) {
       if (id === this.expandedMenuId) {
@@ -49,8 +56,27 @@ export default defineComponent({
       }
       this.expandedMenuId = id
     },
-  },
+    onDocumentClick (e) {
+      this.handleElementClick(e.target)
+    },
+    onKeyDown (e) {
+      if (e.key === 'Escape') {
+        this.toggle(this.expandedMenuId)
+      }
+    },
+    handleElementClick (el) {
+      if (el === document.getElementById(this.id)) {
+        return
+      }
 
+      if (!el?.parentNode) {
+        this.toggle(this.expandedMenuId)
+        return
+      }
+
+      this.handleElementClick(el.parentNode)
+    },
+  },
 })
 </script>
 


### PR DESCRIPTION
Se met en écoute du clic et vérifie si l'élément cliqué est à l'intérieur ou à l'extérieur du menu

Fix: #426 
Fix: #427