### PR TITLE
fix: Set fixed toggle-status-width to avoid label to jiggle when switched on/off

### DIFF
--- a/src/components/DsfrToggleSwitch/DsfrToggleSwitch.vue
+++ b/src/components/DsfrToggleSwitch/DsfrToggleSwitch.vue
@@ -55,6 +55,7 @@ export default defineComponent({
       :for="inputId"
       data-fr-checked-label="Activé"
       data-fr-unchecked-label="Désactivé"
+      style="--toggle-status-width: 3.55208125rem;"
     >
       {{ label }}
     </label>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/380026/213155061-9a1616ef-5ec6-4a1b-a3e5-cd32b3d632cc.png) \
![image](https://user-images.githubusercontent.com/380026/213155092-ff7b8c2e-f56b-454d-81d9-402e676868d5.png)
