### PR TITLE
fix(DsfrFieldset): Missing `fr-fieldset__element` elements to wrap Fieldset hint and content

### DIFF
--- a/src/components/DsfrFieldset/DsfrFieldset.spec.js
+++ b/src/components/DsfrFieldset/DsfrFieldset.spec.js
@@ -29,17 +29,21 @@ describe('DsfrFieldset', () => {
     const hintByText = getByText(hint)
 
     const hintEl = legendEl.nextElementSibling
+    const hintInnerEl = hintEl.firstElementChild
+
+    const contentEl = hintEl.nextElementSibling
 
     expect(fieldsetEl).not.toBeNull()
     expect(fieldsetEl).toHaveClass('fr-fieldset')
     expect(legendEl).toBe(legendByText)
-    expect(fieldsetByText).toBe(fieldsetEl)
-    expect(hintByText).toBe(hintEl)
+    expect(fieldsetByText).toBe(contentEl)
+    expect(hintByText).toBe(hintInnerEl)
     expect(legendEl).toHaveClass('fr-fieldset__legend')
     expect(legendEl).toHaveClass('test-legend-class')
     expect(legendEl).toHaveAttribute('id', 'legend-id')
-    expect(hintEl).toHaveClass('fr-hint-text')
-    expect(hintEl).toHaveClass('test-hint-class')
+    expect(hintEl).toHaveClass('fr-fieldset__element')
+    expect(hintInnerEl).toHaveClass('fr-hint-text')
+    expect(hintInnerEl).toHaveClass('test-hint-class')
   })
 
   it('should render a complex DsfrFieldset component', () => {
@@ -64,14 +68,18 @@ describe('DsfrFieldset', () => {
     const hintByText = getByText(hint)
 
     const hintEl = legendEl.nextElementSibling
+    const hintInnerEl = hintEl.firstElementChild
+
+    const contentEl = hintEl.nextElementSibling
 
     expect(fieldsetEl).not.toBeNull()
     expect(fieldsetEl).toHaveClass('fr-fieldset')
     expect(legendEl).toBe(legendByText)
-    expect(fieldsetByText).toBe(fieldsetEl)
-    expect(hintByText).toBe(hintEl)
+    expect(fieldsetByText).toBe(contentEl)
+    expect(hintByText).toBe(hintInnerEl)
     expect(legendEl).toHaveClass('fr-fieldset__legend')
     expect(legendEl).toHaveAttribute('id', 'legend-id')
-    expect(hintEl).toHaveClass('fr-hint-text')
+    expect(hintEl).toHaveClass('fr-fieldset__element')
+    expect(hintInnerEl).toHaveClass('fr-hint-text')
   })
 })

--- a/src/components/DsfrFieldset/DsfrFieldset.stories.js
+++ b/src/components/DsfrFieldset/DsfrFieldset.stories.js
@@ -91,7 +91,7 @@ export const EnsemblePersonnaliseDeChamps = (args) => ({
       :hint-class="hintClass"
     >
       <template #legend>
-        {{ legend }} avec <em>de l’italique</em>
+        <h6>{{ legend }} avec <em>de l’italique</em> dans un titre</h6>
       </template>
       <template #hint>
         {{ hint }} avec <strong>du gras</strong>

--- a/src/components/DsfrFieldset/DsfrFieldset.vue
+++ b/src/components/DsfrFieldset/DsfrFieldset.vue
@@ -41,17 +41,20 @@ export default defineComponent({
       <!-- @slot Slot pour le contenu du titre du `fieldset` (sera dans `<legend class="fr-fieldset__legend">`). Une props du même nom est utilisable pour du texte simple sans mise en forme. -->
       <slot name="legend" />
     </legend>
-    <span
-      v-if="hint || $slots.hint?.().length"
-      class="fr-hint-text"
-      :class="hintClass"
-    >
+    <div class="fr-fieldset__element">
+      <span
+        v-if="hint || $slots.hint?.().length"
+        class="fr-hint-text"
+        :class="hintClass"
+      >
       {{ hint }}
-      <!-- @slot Slot pour le contenu de l’indice (sera dans `<span class="fr-hint-text">` qui sera dans `</legend>`). Une **props du même nom est utilisable pour du texte simple** sans mise en forme. -->
+        <!-- @slot Slot pour le contenu de l’indice (sera dans `<span class="fr-hint-text">` qui sera dans `</legend>`). Une **props du même nom est utilisable pour du texte simple** sans mise en forme. -->
       <slot name="hint" />
     </span>
-
+    </div>
     <!-- @slot Slot par défaut pour le contenu du fieldset (sera dans `<fieldset>`, après `</legend>`) -->
-    <slot />
+    <div class="fr-fieldset__element">
+      <slot />
+    </div>
   </fieldset>
 </template>

--- a/src/components/DsfrFieldset/DsfrFieldset.vue
+++ b/src/components/DsfrFieldset/DsfrFieldset.vue
@@ -41,9 +41,11 @@ export default defineComponent({
       <!-- @slot Slot pour le contenu du titre du `fieldset` (sera dans `<legend class="fr-fieldset__legend">`). Une props du même nom est utilisable pour du texte simple sans mise en forme. -->
       <slot name="legend" />
     </legend>
-    <div class="fr-fieldset__element">
+    <div
+      v-if="hint || $slots.hint?.().length"
+      class="fr-fieldset__element"
+    >
       <span
-        v-if="hint || $slots.hint?.().length"
         class="fr-hint-text"
         :class="hintClass"
       >


### PR DESCRIPTION
- Actuellement
![image](https://user-images.githubusercontent.com/380026/213199548-77c34cbf-801e-4a15-bbea-a6a58ac0f637.png)

- Devrait ressembler à 
![image](https://user-images.githubusercontent.com/380026/213199434-1459ea44-b085-40e5-a0c8-cd6cc770754e.png)

Exemple d'intégration: https://www.systeme-de-design.gouv.fr/elements-d-interface/modeles-et-blocs-fonctionnels/modele-de-page-de-creation-de-compte