### PR TITLE
fix(DsfrQuote): DsfrQuote should be usable without image

### DIFF
--- a/src/components/DsfrQuote/DsfrQuote.stories.js
+++ b/src/components/DsfrQuote/DsfrQuote.stories.js
@@ -74,3 +74,41 @@ Citation.args = {
   sourceUrl: 'https://www.duckduckgo.com',
   quoteImage: 'https://placekitten.com/g/150/150',
 }
+
+export const CitationSansImage = (args) => ({
+  components: { DsfrQuote },
+  data () {
+    return {
+      ...args,
+    }
+  },
+  template: `
+    <DsfrQuote
+      :quote="quote"
+      :author="author"
+      :details="details"
+      :source="source"
+      :sourceUrl="sourceUrl"
+    />
+  `,
+
+  mounted () {
+    document.body.parentElement.setAttribute('data-fr-theme', this.dark ? 'dark' : 'light')
+  },
+})
+CitationSansImage.args = {
+  dark: false,
+  quote: 'LA citation',
+  author: 'Pierre-Louis EGAUD',
+  details: [
+    'Détail 1',
+    'Détail 2',
+    'Détail 3',
+    {
+      url: 'https://www.wikipedia.fr',
+      label: 'wikipedia',
+    },
+  ],
+  source: 'Duckduckgo',
+  sourceUrl: 'https://www.duckduckgo.com',
+}

--- a/src/components/DsfrQuote/DsfrQuote.vue
+++ b/src/components/DsfrQuote/DsfrQuote.vue
@@ -68,7 +68,7 @@ export default defineComponent({
         </li>
       </ul>
 
-      <div class="fr-quote__image">
+      <div class="fr-quote__image" v-if="quoteImage">
         <img
           :src="quoteImage"
           class="fr-responsive-img"


### PR DESCRIPTION
Exemple: https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/citation

Cela permet de retirer l'image si la props n'est pas définie, et éviter d'avoir un placeholder qui glitch

![image](https://user-images.githubusercontent.com/380026/213256328-c815298f-a4bd-4993-af1c-ab114046ebfd.png)
