### PR TITLE
fix(DsfrButtonGroup): Button group does not respect `sizes` and `inlineLayoutWhen` rules

### DIFF
--- a/src/components/DsfrButton/DsfrButton.stories.js
+++ b/src/components/DsfrButton/DsfrButton.stories.js
@@ -26,6 +26,15 @@ export default {
       control: 'boolean',
       description: 'Permet de basculer sur la variante de style "tertiary"',
     },
+    noOutline: {
+      control: 'boolean',
+      description: 'Permet de basculer sur la variante de style "tertiary-nooutline"',
+    },
+    size: {
+      control: 'radio',
+      options: ['small', 'medium', 'large'],
+      description: 'Indique la taille du groupe de bouton',
+    },
     disabled: {
       control: 'boolean',
       description: 'Indique si le bouton est **inactivé**',
@@ -56,6 +65,8 @@ export const BoutonPrimaire = (args) => ({
       :tertiary="tertiary"
       :disabled="disabled"
       :icon="icon"
+      :size="size"
+      :no-outline="noOutline"
       :icon-only="iconOnly"
       :icon-right="iconRight"
       @click="onClick"
@@ -89,6 +100,8 @@ export const BoutonPrimaireAvecIcone = (args) => ({
       :label="label"
       :disabled="disabled"
       :icon="icon"
+      :size="size"
+      :no-outline="noOutline"
       :icon-right="iconRight"
       @click="onClick"
     />
@@ -118,6 +131,8 @@ export const BoutonSecondaire = (args) => ({
       :label="label"
       :disabled="disabled"
       :secondary="secondary"
+      :no-outline="noOutline"
+      :size="size"
       @click="onClick"
     />
   `,
@@ -145,6 +160,8 @@ export const BoutonTertiaire = (args) => ({
       :label="label"
       :disabled="disabled"
       :tertiary="tertiary"
+      :no-outline="noOutline"
+      :size="size"
       @click="onClick"
     />
   `,
@@ -158,6 +175,36 @@ BoutonTertiaire.args = {
   disabled: false,
   dark: false,
   tertiary: true,
+}
+
+export const BoutonTertiaireSansBordure = (args) => ({
+  components: { DsfrButton },
+  data () {
+    return {
+      ...args,
+    }
+  },
+  template: `
+    <DsfrButton
+      :label="label"
+      :disabled="disabled"
+      :tertiary="tertiary"
+      :no-outline="noOutline"
+      :size="size"
+      @click="onClick"
+    />
+  `,
+
+  mounted () {
+    document.body.parentElement.setAttribute('data-fr-theme', this.dark ? 'dark' : 'light')
+  },
+})
+BoutonTertiaireSansBordure.args = {
+  label: 'Label bouton secondaire',
+  disabled: false,
+  dark: false,
+  tertiary: true,
+  noOutline: true,
 }
 
 export const SuiteDeBoutons = (args) => ({
@@ -177,6 +224,8 @@ export const SuiteDeBoutons = (args) => ({
         :secondary="btn.secondary"
         :label="btn.label"
         :icon="btn.icon"
+        :no-outline="btn.noOutline"
+        :size="btn.size"
         :iconRight="btn.iconRight"
         @click="onClick"
       />

--- a/src/components/DsfrButton/DsfrButton.vue
+++ b/src/components/DsfrButton/DsfrButton.vue
@@ -19,12 +19,39 @@ export default defineComponent({
     },
     secondary: Boolean,
     tertiary: Boolean,
+    noOutline: {
+      type: Boolean,
+      default: false,
+    },
     icon: {
       type: String,
       default: undefined,
     },
+    size: {
+      type: String,
+      validator: (val) => ['sm', 'small', 'lg', 'large', 'md', 'medium', '', undefined].includes(val),
+      default: undefined,
+    },
     iconRight: Boolean,
     iconOnly: Boolean,
+  },
+
+  computed: {
+    sm () {
+      return ['sm', 'small'].includes(this.size)
+    },
+    md () {
+      return ['md', 'medium'].includes(this.size)
+    },
+    lg () {
+      return ['lg', 'large'].includes(this.size)
+    },
+    center () {
+      return this.align === 'center'
+    },
+    right () {
+      return this.align === 'right'
+    },
   },
 
   methods: {
@@ -41,7 +68,11 @@ export default defineComponent({
     :class="{
       'fr-btn': true,
       'fr-btn--secondary': secondary && !tertiary,
-      'fr-btn--tertiary': tertiary && !secondary,
+      'fr-btn--tertiary': tertiary && !secondary && !noOutline,
+      'fr-btn--tertiary-no-outline': tertiary && !secondary && noOutline,
+      'fr-btn--sm': sm,
+      'fr-btn--md': md,
+      'fr-btn--lg': lg,
       'inline-flex': true,
       'reverse': iconRight,
       'justify-center': iconOnly,

--- a/src/components/DsfrButton/DsfrButtonGroup.spec.js
+++ b/src/components/DsfrButton/DsfrButtonGroup.spec.js
@@ -51,7 +51,7 @@ describe('DsfrButtonGroup', () => {
     expect(secondButtonSpan.parentNode).toHaveClass('fr-btn--secondary')
     expect(wrapper).toHaveClass('extra-class')
     expect(wrapper).not.toHaveClass('fr-btns-group--right')
-    expect(wrapper).not.toHaveClass('fr-btns-group--inline-sm')
+    expect(wrapper).not.toHaveClass('fr-btns-group--sm')
     expect(onClickFirst.callCount).toBe(1)
     expect(onClickSecond.callCount).toBe(1)
   })
@@ -80,6 +80,6 @@ describe('DsfrButtonGroup', () => {
     // Then
     expect(wrapper).toHaveClass('extra-class')
     expect(wrapper).toHaveClass('fr-btns-group--right')
-    expect(wrapper).toHaveClass('fr-btns-group--inline-sm')
+    expect(wrapper).toHaveClass('fr-btns-group--sm')
   })
 })

--- a/src/components/DsfrButton/DsfrButtonGroup.stories.js
+++ b/src/components/DsfrButton/DsfrButtonGroup.stories.js
@@ -20,15 +20,25 @@ export default {
     },
     inline: {
       control: 'boolean',
-      description: 'Indique si le groupe de boutons doit apparaître en empilement horizontal',
+      deprecated: true,
+      description: '**Déprécié:** Indique si le groupe de boutons doit toujours apparaître en empilement horizontal. *Utiliser `inlineLayoutWhen` à la place.*',
+    },
+    inlineLayoutWhen: {
+      control: 'radio',
+      options: ['never', 'always', 'small', 'medium', 'large'],
+      description: 'Indique si le groupe de boutons doit apparaître en empilement horizontal (toujours, ou seulement sur les tailles de vue spécifiées)',
     },
     reverse: {
       control: 'boolean',
       description: 'Indique si l’ordre des boutons doit être inversé par rapport au DOM.\n\n *N.B. : Ne fonctionne que si `align` est à `right`*',
     },
+    iconRight: {
+      control: 'boolean',
+      description: 'Inverse la position des icônes par rapport au texte.\n\n *N.B. : Ne fonctionne que si la prop n\'est pas définie sur chaque bouton*',
+    },
     size: {
       control: 'radio',
-      options: ['default', 'small', 'medium', 'large'],
+      options: ['small', 'medium', 'large'],
       description: 'Indique la taille du groupe de bouton',
     },
     align: {
@@ -57,6 +67,8 @@ export const GroupeDeBoutons = (args) => ({
       :size="size"
       :align="align"
       :inline="inline"
+      :inline-layout-when="inlineLayoutWhen"
+      :icon-right="iconRight"
       :reverse="reverse"
     />
   `,
@@ -69,9 +81,9 @@ export const GroupeDeBoutons = (args) => ({
 GroupeDeBoutons.args = {
   dark: false,
   align: 'center',
-  inline: false,
+  inlineLayoutWhen: false,
   reverse: false,
-  size: undefined,
+  iconRight: false,
   buttons: [
     {
       label: 'Label 1',
@@ -85,13 +97,11 @@ GroupeDeBoutons.args = {
     {
       label: 'Label 3',
       icon: 'ri-checkbox-circle-line',
-      iconRight: true,
     },
     {
       label: 'Label 4',
       secondary: true,
       icon: 'ri-checkbox-circle-line',
-      iconRight: true,
     },
   ],
 }

--- a/src/components/DsfrButton/DsfrButtonGroup.vue
+++ b/src/components/DsfrButton/DsfrButtonGroup.vue
@@ -14,13 +14,26 @@ export default defineComponent({
       type: Array,
       default: () => [],
     },
-    inline: Boolean,
+    /**
+     * @deprecated Use inlineLayoutWhen instead
+     */
+    inline: {
+      type: Boolean,
+      default: false,
+      deprecated: 'Use "inlineLayoutWhen" prop instead',
+    },
+    inlineLayoutWhen: {
+      type: String,
+      validator: (val) => ['always', 'never', 'sm', 'small', 'lg', 'large', 'md', 'medium', '', undefined, true, false].includes(val),
+      default: 'never',
+    },
     size: {
       type: String,
       validator: (val) => ['sm', 'small', 'lg', 'large', 'md', 'medium', '', undefined].includes(val),
       default: undefined,
     },
     reverse: Boolean,
+    iconRight: Boolean,
     align: {
       type: String,
       validator: (val) => ['right', 'center', '', undefined].includes(val),
@@ -38,6 +51,18 @@ export default defineComponent({
     lg () {
       return ['lg', 'large'].includes(this.size)
     },
+    inlineAlways () {
+      return this.inline || ['always', true].includes(this.inlineLayoutWhen)
+    },
+    inlineSm () {
+      return ['sm', 'small'].includes(this.inlineLayoutWhen)
+    },
+    inlineMd () {
+      return ['md', 'medium'].includes(this.inlineLayoutWhen)
+    },
+    inlineLg () {
+      return ['lg', 'large'].includes(this.inlineLayoutWhen)
+    },
     center () {
       return this.align === 'center'
     },
@@ -52,12 +77,16 @@ export default defineComponent({
   <ul
     class="fr-btns-group"
     :class="{
-      'fr-btns-group--inline': inline,
-      'fr-btns-group--inline-sm': sm,
-      'fr-btns-group--inline-md': md,
-      'fr-btns-group--inline-lg': lg,
+      'fr-btns-group--inline': inlineAlways,
+      'fr-btns-group--sm': sm,
+      'fr-btns-group--md': md,
+      'fr-btns-group--lg': lg,
+      'fr-btns-group--inline-sm': inlineSm,
+      'fr-btns-group--inline-md': inlineMd,
+      'fr-btns-group--inline-lg': inlineLg,
       'fr-btns-group--center': center,
       'fr-btns-group--right': right,
+      'fr-btns-group--icon-right': iconRight,
       'fr-btns-group--inline-reverse': reverse,
     }"
     data-testid="fr-btns"


### PR DESCRIPTION
Corrige le comportement des Groupes de Bouton:

Il y avait une inconpréhension entre les classes pour définir la taille des boutons et les classes pour passer en `inline` à des breakpoints définis:

- La taille n'était pas définie sur les boutons
- La taille n'était pas definie sur le groupe avec les classes `fr-btns-group--sm|md|lg`
- Le comportement `inline` n'était pas correct, j'ai déprécié la prop `inline` pour utiliser `inlineLayoutWhen` qui permet de choisir entre `never|always|small|medium|large`. Ce qui correspond aux classes `fr-btns-group--inline` ou bien `fr-btns-group--inline-sm|md|lg`
- Il manquait le style bouton `tertiary-no-outline`

BREAKING CHANGE: Button group `inline` prop is deprecated in favor of `inlineLayoutWhen`