### PR TITLE
fix(DsfrFooter): Removed useless VIcon on licence link, bind Storybook props

### DIFF
--- a/src/components/DsfrFooter/DsfrFooter.stories.js
+++ b/src/components/DsfrFooter/DsfrFooter.stories.js
@@ -137,6 +137,10 @@ export const PiedDePageSimple = (args) => ({
     :home-link="homeLink"
     :partners="partners"
     :ecosystem-links="ecosystemLinks"
+    :licence-text="licenceText"
+    :licence-to="licenceTo"
+    :licence-name="licenceName"
+    :licence-link-props="licenceLinkProps"
   >
     <template v-slot:description>
       <p>
@@ -166,6 +170,10 @@ PiedDePageSimple.args = {
   a11yComplianceLink: '/a11y-conformite',
   descText: 'Description',
   homeLink: '/',
+  licenceText: undefined,
+  licenceTo: undefined,
+  licenceName: undefined,
+  licenceLinkProps: undefined,
   ecosystemLinks: [
     {
       label: 'legifrance.gouv.fr',
@@ -236,6 +244,10 @@ export const PiedDePageAvecLogoOperateur = (args) => ({
     :operator-img-style="operatorImgStyle"
     :operator-img-src="operatorImgSrc"
     :operator-img-alt="operatorImgAlt"
+    :licence-text="licenceText"
+    :licence-to="licenceTo"
+    :licence-name="licenceName"
+    :licence-link-props="licenceLinkProps"
   >
     <template #footer-link-lists>
       <DsfrFooterLinkList
@@ -277,6 +289,10 @@ PiedDePageAvecLogoOperateur.args = {
   a11yComplianceLink: '/a11y-conformite',
   descText: 'Description',
   homeLink: '/',
+  licenceText: undefined,
+  licenceTo: undefined,
+  licenceName: undefined,
+  licenceLinkProps: undefined,
   categoryName1: 'Nom de la categorie 1',
   linkList1: [
     { label: 'Lien 1.1', to: '/lien1/1' },

--- a/src/components/DsfrFooter/DsfrFooter.vue
+++ b/src/components/DsfrFooter/DsfrFooter.vue
@@ -259,15 +259,11 @@ export default defineComponent({
               class="fr-link-licence  no-content-after"
               :to="routerLinkLicenceTo"
               :href="aLicenceHref"
-              target="_blank"
+              :target="isExternalLink ? '_blank' : undefined"
               rel="noopener noreferrer"
               v-bind="licenceLinkProps"
             >
               {{ licenceName }}
-              <VIcon
-                v-if="isExternalLink"
-                name="ri-external-link-line"
-              />
             </component>
           </p>
         </div>


### PR DESCRIPTION
- L'icone external est déjà gérée en CSS, pas besoin de l'ajouter à la main
- Les props `licence*` n'etaient pas bindées dans Storybook
- Retirer le target `_blank` si la page de license est interne