### PR TITLE
fix: Fixed and improved Accordions

### DIFF
--- a/src/components/DsfrAccordion/DsfrAccordion.stories.js
+++ b/src/components/DsfrAccordion/DsfrAccordion.stories.js
@@ -100,24 +100,26 @@ export const AccordeonDansUnAccordeon = (args) => ({
           :expanded-id="expandedId"
           @expand="expandedId = $event"
         >
-          <li>
-            <DsfrAccordion
-              :title="titleSub1"
-              :expanded-id="subExpandedId"
-              @expand="subExpandedId = $event"
-            >
-              Contenu de l’accordéon dans l’accordéon
-            </DsfrAccordion>
-          </li>
-          <li>
-            <DsfrAccordion
-              :title="titleSub2"
-              :expanded-id="subExpandedId"
-              @expand="subExpandedId = $event"
-            >
-              Contenu de l’accordéon dans l’accordéon
-            </DsfrAccordion>
-          </li>
+          <DsfrAccordionsGroup>
+            <li>
+              <DsfrAccordion
+                :title="titleSub1"
+                :expanded-id="subExpandedId"
+                @expand="subExpandedId = $event"
+              >
+                Contenu de l’accordéon dans l’accordéon
+              </DsfrAccordion>
+            </li>
+            <li>
+              <DsfrAccordion
+                :title="titleSub2"
+                :expanded-id="subExpandedId"
+                @expand="subExpandedId = $event"
+              >
+                Contenu de l’accordéon dans l’accordéon
+              </DsfrAccordion>
+            </li>
+          </DsfrAccordionsGroup>
         </DsfrAccordion>
       </li>
     </DsfrAccordionsGroup>

--- a/src/components/DsfrAccordion/DsfrAccordion.vue
+++ b/src/components/DsfrAccordion/DsfrAccordion.vue
@@ -24,11 +24,39 @@ export default defineComponent({
       default: 'Sans intitulé',
     },
   },
+
   emits: ['expand'],
+
+  data () {
+    return {
+      collapsing: false,
+    }
+  },
 
   computed: {
     expanded () {
       return this.expandedId === this.id
+    },
+  },
+
+  watch: {
+    /*
+     * @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js
+     */
+    expanded (newValue, oldValue) {
+      if (newValue !== oldValue) {
+        if (newValue === true) {
+          this.$refs.collapse.style.setProperty('--collapse-max-height', 'none')
+        }
+        this.collapsing = true
+        this.adjust()
+        setTimeout(() => {
+          this.collapsing = false
+          if (newValue === false) {
+            this.$refs.collapse.style.removeProperty('--collapse-max-height')
+          }
+        }, 300)
+      }
     },
   },
 
@@ -42,6 +70,15 @@ export default defineComponent({
       } else {
         this.$emit('expand', this.id)
       }
+    },
+    /*
+     * @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js#L61
+     */
+    adjust () {
+      this.$refs.collapse.style.setProperty('--collapser', 'none')
+      const height = this.$refs.collapse.offsetHeight
+      this.$refs.collapse.style.setProperty('--collaspe', -height + 'px')
+      this.$refs.collapse.style.setProperty('--collapser', '')
     },
   },
 
@@ -66,8 +103,12 @@ export default defineComponent({
     </h3>
     <div
       :id="id"
+      ref="collapse"
       class="fr-collapse"
-      :class="{ 'fr-collapse--expanded': expanded }"
+      :class="{
+        'fr-collapse--expanded': expanded,
+        'fr-collapsing': collapsing,
+      }"
     >
       <!-- @slot Slot par défaut pour le contenu de l’accordéon: sera dans `<div class="fr-collapse">` -->
       <slot />
@@ -76,9 +117,3 @@ export default defineComponent({
 </template>
 
 <style src="@gouvfr/dsfr/dist/component/accordion/accordion.main.min.css" />
-
-<style scoped>
-.fr-collapse--expanded {
-  max-height: none !important;
-}
-</style>

--- a/src/components/DsfrAccordion/DsfrAccordion.vue
+++ b/src/components/DsfrAccordion/DsfrAccordion.vue
@@ -34,7 +34,14 @@ export default defineComponent({
 
   methods: {
     toggleExpanded () {
-      this.$emit('expand', this.id)
+      /*
+       * Close current accordion if expanded
+       */
+      if (this.expanded) {
+        this.$emit('expand', undefined)
+      } else {
+        this.$emit('expand', this.id)
+      }
     },
   },
 

--- a/src/components/DsfrAccordion/DsfrAccordion.vue
+++ b/src/components/DsfrAccordion/DsfrAccordion.vue
@@ -77,7 +77,7 @@ export default defineComponent({
     adjust () {
       this.$refs.collapse.style.setProperty('--collapser', 'none')
       const height = this.$refs.collapse.offsetHeight
-      this.$refs.collapse.style.setProperty('--collaspe', -height + 'px')
+      this.$refs.collapse.style.setProperty('--collapse', -height + 'px')
       this.$refs.collapse.style.setProperty('--collapser', '')
     },
   },

--- a/src/utils/random-utils.js
+++ b/src/utils/random-utils.js
@@ -1,4 +1,7 @@
-export const alphanum = 'abcdefghijklmnopqrstuvwyz0123456789'
+const alphanumBase = 'abcdefghijklmnopqrstuvwyz0123456789'
+// We need to duplicate the base string to have a longer string
+// to avoid Math.random to return the same value twice
+export const alphanum = alphanumBase.repeat(10)
 
 export const getRandomAlphaNum = () => {
   const randomIndex = Math.floor(Math.random() * alphanum.length)


### PR DESCRIPTION
- On ne pouvait pas fermer un accordion
- J'ai essayé de porter [le code JS du DSFR](https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js#L61) pour setter les variables CSS pendant l'animation des accordions 
- Il manquait un AccordionGroup dans l'exemple Storybook, ça ajoutait une marge