### PR TITLE
feat: :sparkles: allow mailto links in DsfrHeaderMenuLink

### DIFF
--- a/src/components/DsfrHeader/DsfrHeaderMenuLink.spec.js
+++ b/src/components/DsfrHeader/DsfrHeaderMenuLink.spec.js
@@ -1,0 +1,60 @@
+import { render } from '@testing-library/vue'
+
+import DsfrHeaderMenuLink from './DsfrHeaderMenuLink.vue'
+
+describe('DsfrHeaderMenuLink', () => {
+  it('should render DsfrHeaderMenuLink with a router link', async () => {
+    // Given
+    const to = '/path1'
+    const label = 'One'
+
+    // When
+    const { getByText } = render(DsfrHeaderMenuLink, {
+      props: {
+        to,
+        label,
+      },
+    })
+
+    const quickLink = getByText(label)
+
+    // Then
+    expect(quickLink).toHaveAttribute('to', to)
+  })
+  it('should render DsfrHeaderMenuLink with an external link', async () => {
+    // Given
+    const href = 'https://design.numerique.gouv.fr/'
+    const label = 'DesignGouv'
+
+    // When
+    const { getByText } = render(DsfrHeaderMenuLink, {
+      props: {
+        href,
+        label,
+      },
+    })
+
+    const quickLink = getByText(label)
+
+    // Then
+    expect(quickLink).toHaveAttribute('href', href)
+  })
+  it('should render DsfrHeaderMenuLink with a mailto link', async () => {
+    // Given
+    const href = 'mailto:vue-dsfr@interieur.gouv.fr'
+    const label = 'Nous contacter'
+
+    // When
+    const { getByText } = render(DsfrHeaderMenuLink, {
+      props: {
+        href,
+        label,
+      },
+    })
+
+    const quickLink = getByText(label)
+
+    // Then
+    expect(quickLink).toHaveAttribute('href', href)
+  })
+})

--- a/src/components/DsfrHeader/DsfrHeaderMenuLink.vue
+++ b/src/components/DsfrHeader/DsfrHeaderMenuLink.vue
@@ -52,22 +52,25 @@ export default defineComponent({
       if (this.button) {
         return 'button'
       }
-      return this.isExternalLink ? 'a' : 'RouterLink'
+      return this.isExternalLink || this.isMailto ? 'a' : 'RouterLink'
     },
     isPathString () {
       return typeof this.path === 'string'
     },
     isExternalLink () {
-      return this.href !== undefined || (this.isPathString && this.path.startsWith('http'))
+      return this.href?.startsWith('http') || (this.isPathString && this.path.startsWith('http'))
+    },
+    isMailto () {
+      return this.href?.startsWith('mailto') || (this.isPathString && this.path.startsWith('mailto'))
     },
     actualHref () {
-      if (!this.isExternalLink) {
+      if (!this.isExternalLink && !this.isMailto) {
         return undefined
       }
       return this.href !== undefined ? this.href : this.path
     },
     actualTo () {
-      if (this.isExternalLink) {
+      if (this.isExternalLink || this.isMailto) {
         return undefined
       }
       return this.to || this.path


### PR DESCRIPTION
Closes #511 => permettre d'avoir un lien de type `mailto` dans les `quickLinks` d'un `DsfrHeader`