### PR TITLE
feat: ✨ Ajoute l'icône optionnelle au DsfrNavigationMenuLink

### DIFF
--- a/src/components/DsfrNavigation/DsfrNavigationMenuLink.spec.js
+++ b/src/components/DsfrNavigation/DsfrNavigationMenuLink.spec.js
@@ -15,7 +15,32 @@ const router = createRouter({
 })
 
 describe('DsfrNavigationMenuLink', () => {
-  it('should render a navigation menu link (internal)', async () => {
+  it('should render a navigation menu link (internal) with icon', async () => {
+    const to = '/'
+    const text = 'Texte du lien'
+    const icon = 'ri-home-2-line'
+
+    const { getByTestId } = render(DsfrNavigationMenuLink, {
+      global: {
+        plugins: [router],
+        components: {
+          VIcon,
+        },
+      },
+      props: {
+        to,
+        text,
+        icon,
+      },
+    })
+
+    await router.isReady()
+
+    const link = getByTestId('nav-router-link')
+    expect(link.innerHTML).toBe('<svg class="ov-icon" style="font-size: 1.2em;" aria-hidden="true" width="0" height="0" viewBox="0 0 0 0" fill="currentColor"></svg> ' + text)
+    expect(link).toHaveAttribute('href', to)
+  })
+  it('should render a navigation menu link (internal) without icon', async () => {
     const to = '/'
     const text = 'Texte du lien'
 
@@ -35,7 +60,7 @@ describe('DsfrNavigationMenuLink', () => {
     await router.isReady()
 
     const link = getByTestId('nav-router-link')
-    expect(link.innerHTML).toBe(text)
+    expect(link.innerHTML).toBe('<!--v-if--> ' + text)
     expect(link).toHaveAttribute('href', to)
   })
 })

--- a/src/components/DsfrNavigation/DsfrNavigationMenuLink.stories.js
+++ b/src/components/DsfrNavigation/DsfrNavigationMenuLink.stories.js
@@ -3,6 +3,11 @@ import DsfrNavigation from './DsfrNavigation.vue'
 
 import { setup } from '@storybook/vue3'
 
+import { addIcons } from 'oh-vue-icons'
+import { RiHome2Line } from 'oh-vue-icons/icons/ri/index.js'
+
+addIcons(RiHome2Line)
+
 const RouterLink = {
   name: 'RouterLink',
   props: {
@@ -33,6 +38,10 @@ export default {
       control: 'text',
       description: '(Optionnel) Valeur de l’attribut `id` de la balise `<a>` du lien de navigation. Aura une valeur pseudo-aléatoire par défaut',
     },
+    icon: {
+      control: 'text',
+      description: '(Optionnel) **Nom de l’icône** (tel que sur le site [RemixIcon](https://remixicon.com), exemple: `"ri-search-line"`) à afficher à côté du texte du bouton.\n\n Par défaut, l’icône est à gauche',
+    },
     'toggle-id': {
       description: 'Événement émis lors du click sur le lien, avec en argument l’id de l’élément cliqué',
     },
@@ -54,14 +63,15 @@ export const NavigationLienMenu = (args) => ({
     <DsfrNavigationMenuLink
       :to="to"
       :text="text"
+      :icon="icon"
       @click.prevent.stop=""
     />
   </DsfrNavigation>
   `,
 
-
 })
 NavigationLienMenu.args = {
   to: '#test-navigation-menu-link',
   text: 'Lien de menu',
+  icon: 'ri-home-2-line',
 }

--- a/src/components/DsfrNavigation/DsfrNavigationMenuLink.vue
+++ b/src/components/DsfrNavigation/DsfrNavigationMenuLink.vue
@@ -1,9 +1,14 @@
 <script>
 import { defineComponent } from 'vue'
+import { OhVueIcon as VIcon } from 'oh-vue-icons'
 import { getRandomId } from '../../utils/random-utils.js'
 
 export default defineComponent({
   name: 'DsfrNavigationMenuLink',
+
+  components: {
+    VIcon,
+  },
 
   props: {
     id: {
@@ -17,6 +22,11 @@ export default defineComponent({
     text: {
       type: String,
       required: true,
+    },
+    icon: {
+      type: String,
+      required: false,
+      default: undefined,
     },
   },
 
@@ -47,6 +57,10 @@ export default defineComponent({
     :to="to"
     @click="$emit('toggle-id', id)"
   >
+    <VIcon
+      v-if="icon"
+      :name="icon"
+    />
     {{ text }}
   </RouterLink>
 </template>


### PR DESCRIPTION
Comme échanger sur #498 voici ma proposition de PR

J'ai pas mal galéré ... car il semblerait que les configurations js, ts et surtout vitest ne supportent pas windows OS sur ce projet.
😄  Je fais parti des rares adeptes de cet OS...

J'ai pris des erreur d'import sur les tests utilisant `@/../../` par exemple `Error: Failed to load url E:/E:/vue-dsfr/tests/unit/test-utils.js` 


Mais bon, j'ai réussi à faire tourner les tests du DsfrNavigationMenuLink donc voici ma proposition pour ajouter une icône facultative.

Ps: pourquoi utiliser [testing-library](https://testing-library.com/) au lieu de [vue-test-utils](https://test-utils.vuejs.org/guide/) ? Je suis curieux ^^