### PR TITLE
fix(DsfrPagination): Missing prev and next page links text

### DIFF
--- a/src/components/DsfrPagination/DsfrPagination.vue
+++ b/src/components/DsfrPagination/DsfrPagination.vue
@@ -100,7 +100,7 @@ export default defineComponent({
           :title="prevPageTitle"
           :disabled="currentPage === 0 ? true : null"
           @click.prevent="toPreviousPage()"
-        />
+        >{{ prevPageTitle }}</a>
       </li>
       <li
         v-for="(page, idx) in displayedPages"
@@ -125,7 +125,7 @@ export default defineComponent({
           :title="nextPageTitle"
           :disabled="currentPage === pages.length - 1 ? true : null"
           @click.prevent="toNextPage()"
-        />
+        >{{ nextPageTitle }}</a>
       </li>
       <li>
         <a


### PR DESCRIPTION
https://react-dsfr-components.etalab.studio/?path=/docs/components-pagination--default

Pagination should display prev and next labels. They're auto hidden in SM breakpoint.

![image](https://user-images.githubusercontent.com/380026/233032997-afc882d7-4c3b-4b32-a106-1c4c53054de2.png)
