### PR TITLE
fix: Fix collapsable behaviour using a new composable

### DIFF
--- a/src/components/DsfrAccordion/DsfrAccordion.spec.js
+++ b/src/components/DsfrAccordion/DsfrAccordion.spec.js
@@ -9,7 +9,7 @@ describe('DsfrAccordion', () => {
     const title = 'Intitulé de l’accordéon'
     const content = 'Contenu de l’accordéon'
 
-    const { getByText } = render(DsfrAccordion, {
+    const { getByText, emitted } = render(DsfrAccordion, {
       global: {
         components: {
           VIcon,
@@ -17,7 +17,7 @@ describe('DsfrAccordion', () => {
       },
       props: {
         title,
-        id: '1',
+        id: 'accordion-1',
         expandedId: undefined,
       },
       slots: {
@@ -29,14 +29,16 @@ describe('DsfrAccordion', () => {
     const contentEl = getByText(content)
 
     expect(contentEl).toHaveClass('fr-collapse')
+    expect(contentEl).toHaveAttribute('id', 'accordion-1')
     expect(titleEl.parentNode).toHaveClass('fr-accordion__btn')
     expect(titleEl.parentNode.parentNode).toHaveClass('fr-accordion__title')
     expect(titleEl.parentNode.parentNode.parentNode).toHaveClass('fr-accordion')
 
-    await fireEvent.click(titleEl)
-    // need to wait RAF
-    await (new Promise(resolve => setTimeout(resolve, 100)))
+    await fireEvent.click(titleEl.parentNode)
 
-    expect(contentEl).toHaveClass('fr-collapse--expanded')
+    expect(emitted()).toHaveProperty('expand')
+    expect(emitted().expand).toStrictEqual([['accordion-1']])
+
+    // Cannot test expandedId because Component is not wrapped in a listening Vue instance
   })
 })

--- a/src/components/DsfrAccordion/DsfrAccordion.spec.js
+++ b/src/components/DsfrAccordion/DsfrAccordion.spec.js
@@ -18,7 +18,7 @@ describe('DsfrAccordion', () => {
       props: {
         title,
         id: '1',
-        expandedId: '1',
+        expandedId: undefined,
       },
       slots: {
         default: content,
@@ -28,12 +28,15 @@ describe('DsfrAccordion', () => {
     const titleEl = getByText(title)
     const contentEl = getByText(content)
 
-    await fireEvent.click(titleEl)
-
+    expect(contentEl).toHaveClass('fr-collapse')
     expect(titleEl.parentNode).toHaveClass('fr-accordion__btn')
     expect(titleEl.parentNode.parentNode).toHaveClass('fr-accordion__title')
     expect(titleEl.parentNode.parentNode.parentNode).toHaveClass('fr-accordion')
+
+    await fireEvent.click(titleEl)
+    // need to wait RAF
+    await (new Promise(resolve => setTimeout(resolve, 100)))
+
     expect(contentEl).toHaveClass('fr-collapse--expanded')
-    expect(contentEl).toHaveClass('fr-collapse')
   })
 })

--- a/src/components/DsfrAccordion/DsfrAccordion.stories.js
+++ b/src/components/DsfrAccordion/DsfrAccordion.stories.js
@@ -1,5 +1,6 @@
 import DsfrAccordion from './DsfrAccordion.vue'
 import DsfrAccordionsGroup from './DsfrAccordionsGroup.vue'
+import DsfrCheckboxSet from '../DsfrCheckbox/DsfrCheckboxSet.vue'
 
 /**
  * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/accordeon/)
@@ -166,4 +167,67 @@ export const AccordeonTitreCustom = (args) => ({
 AccordeonTitreCustom.args = {
   title1: 'Un titre d’accordéon customisé',
   title2: 'Un autre titre d’accordéon',
+}
+
+export const AccordeonAvecCheckbox = (args) => ({
+  components: {
+    DsfrAccordion,
+    DsfrAccordionsGroup,
+    DsfrCheckboxSet,
+  },
+
+  data () {
+    return {
+      ...args,
+      expandedId: undefined,
+      accordions: args.accordions,
+    }
+  },
+
+  template: `
+    <dsfr-accordions-group>
+      <li
+        v-for="(accordion, name) in accordions"
+        :id="\`accordion_${name}\`"
+        :key="name"
+      >
+        <dsfr-accordion
+          :id="name"
+          :title="name"
+          :expanded-id="expandedId"
+          @expand="id => expandedId = id"
+        >
+          <dsfr-checkbox-set
+            :options="accordion.options"
+            small
+          />
+        </dsfr-accordion>
+      </li>
+    </dsfr-accordions-group>
+  `,
+})
+AccordeonAvecCheckbox.args = {
+  accordions: {
+    'Accordéon 1': {
+      options: [
+        { label: 'Option 1', value: 'option1' },
+        { label: 'Option 2', value: 'option2' },
+        { label: 'Option 3', value: 'option3' },
+      ],
+    },
+    'Accordéon 2': {
+      options: [
+        { label: 'Option 1', value: 'option1' },
+        { label: 'Option 2', value: 'option2' },
+        { label: 'Option 3', value: 'option3' },
+      ],
+    },
+    'Accordéon 3': {
+      options: [
+        { label: 'Option 1', value: 'option1' },
+        { label: 'Option 2', value: 'option2' },
+        { label: 'Option 3', value: 'option3' },
+      ],
+    },
+  },
 }

--- a/src/components/DsfrAccordion/DsfrAccordion.stories.js
+++ b/src/components/DsfrAccordion/DsfrAccordion.stories.js
@@ -69,6 +69,33 @@ Accordeon.args = {
   title: 'Un titre d’accordéon',
 }
 
+export const AccordeonSimple = (args) => ({
+  components: {
+    DsfrAccordion,
+  },
+
+  data () {
+    return {
+      ...args,
+      expandedId: undefined,
+      title1: args.title + ' 1',
+    }
+  },
+
+  template: `
+    <DsfrAccordion
+      :title="title1"
+      :expanded-id="expandedId"
+      @expand="expandedId = $event"
+    >
+    Contenu de l’accordéon 1
+    </DsfrAccordion>
+  `,
+})
+AccordeonSimple.args = {
+  title: 'Un titre d’accordéon',
+}
+
 export const AccordeonDejaOuvert = (args) => ({
   components: {
     DsfrAccordion,

--- a/src/components/DsfrAccordion/DsfrAccordion.stories.js
+++ b/src/components/DsfrAccordion/DsfrAccordion.stories.js
@@ -69,6 +69,50 @@ Accordeon.args = {
   title: 'Un titre d’accordéon',
 }
 
+export const AccordeonDejaOuvert = (args) => ({
+  components: {
+    DsfrAccordion,
+    DsfrAccordionsGroup,
+  },
+
+  data () {
+    return {
+      ...args,
+      expandedId: 'accordeon-1',
+      title1: args.title + ' 1',
+      title2: args.title + ' 2',
+    }
+  },
+
+  template: `
+  <DsfrAccordionsGroup>
+    <li>
+      <DsfrAccordion
+        :title="title1"
+        id="accordeon-1"
+        :expanded-id="expandedId"
+        @expand="expandedId = $event"
+      >
+        Contenu de l’accordéon 1
+      </DsfrAccordion>
+    </li>
+    <li>
+      <DsfrAccordion
+        :title="title2"
+        id="accordeon-2"
+        :expanded-id="expandedId"
+        @expand="expandedId = $event"
+      >
+        Contenu de l’accordéon 2
+      </DsfrAccordion>
+    </li>
+  </DsfrAccordionsGroup>
+  `,
+})
+AccordeonDejaOuvert.args = {
+  title: 'Un titre d’accordéon',
+}
+
 export const AccordeonDansUnAccordeon = (args) => ({
   components: {
     DsfrAccordion,

--- a/src/components/DsfrAccordion/DsfrAccordion.stories.js
+++ b/src/components/DsfrAccordion/DsfrAccordion.stories.js
@@ -210,23 +210,23 @@ AccordeonAvecCheckbox.args = {
   accordions: {
     'Accordéon 1': {
       options: [
-        { label: 'Option 1', value: 'option1' },
-        { label: 'Option 2', value: 'option2' },
-        { label: 'Option 3', value: 'option3' },
+        { label: 'Option 1', value: 'option1', name: 'option1' },
+        { label: 'Option 2', value: 'option2', name: 'option2' },
+        { label: 'Option 3', value: 'option3', name: 'option3' },
       ],
     },
     'Accordéon 2': {
       options: [
-        { label: 'Option 1', value: 'option1' },
-        { label: 'Option 2', value: 'option2' },
-        { label: 'Option 3', value: 'option3' },
+        { label: 'Option 1', value: 'option1', name: 'option1' },
+        { label: 'Option 2', value: 'option2', name: 'option2' },
+        { label: 'Option 3', value: 'option3', name: 'option3' },
       ],
     },
     'Accordéon 3': {
       options: [
-        { label: 'Option 1', value: 'option1' },
-        { label: 'Option 2', value: 'option2' },
-        { label: 'Option 3', value: 'option3' },
+        { label: 'Option 1', value: 'option1', name: 'option1' },
+        { label: 'Option 2', value: 'option2', name: 'option2' },
+        { label: 'Option 3', value: 'option3', name: 'option3' },
       ],
     },
   },

--- a/src/components/DsfrAccordion/DsfrAccordion.vue
+++ b/src/components/DsfrAccordion/DsfrAccordion.vue
@@ -46,16 +46,12 @@ export default defineComponent({
     expanded (newValue, oldValue) {
       if (newValue !== oldValue) {
         if (newValue === true) {
+          // unbound
+          // @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js#L33
           this.$refs.collapse.style.setProperty('--collapse-max-height', 'none')
         }
         this.collapsing = true
         this.adjust()
-        setTimeout(() => {
-          this.collapsing = false
-          if (newValue === false) {
-            this.$refs.collapse.style.removeProperty('--collapse-max-height')
-          }
-        }, 300)
       }
     },
   },
@@ -80,8 +76,16 @@ export default defineComponent({
       this.$refs.collapse.style.setProperty('--collapse', -height + 'px')
       this.$refs.collapse.style.setProperty('--collapser', '')
     },
+    /*
+     * @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js#L25
+     */
+    onTransitionEnd () {
+      this.collapsing = false
+      if (this.expanded === false) {
+        this.$refs.collapse.style.removeProperty('--collapse-max-height')
+      }
+    },
   },
-
 })
 </script>
 
@@ -109,6 +113,7 @@ export default defineComponent({
         'fr-collapse--expanded': expanded,
         'fr-collapsing': collapsing,
       }"
+      @transitionend="onTransitionEnd"
     >
       <!-- @slot Slot par défaut pour le contenu de l’accordéon: sera dans `<div class="fr-collapse">` -->
       <slot />

--- a/src/components/DsfrAccordion/DsfrAccordion.vue
+++ b/src/components/DsfrAccordion/DsfrAccordion.vue
@@ -120,3 +120,13 @@ export default defineComponent({
     </div>
   </section>
 </template>
+<style>
+/*
+ * Temporary style override to fix Collapsable animations
+ * TODO: remove when fixed
+ */
+.fr-accordion .fr-collapse--expanded {
+  padding-bottom: 0;
+  padding-top: 0;
+}
+</style>

--- a/src/components/DsfrBreadcrumb/DsfrBreadcrumb.vue
+++ b/src/components/DsfrBreadcrumb/DsfrBreadcrumb.vue
@@ -24,8 +24,57 @@ export default defineComponent({
 
   data () {
     return {
-      hideButton: false,
+      collapsing: false,
+      // Need to handle a separate data to add/remove the class after a RAF
+      cssExpanded: false,
+      expanded: false,
     }
+  },
+
+  watch: {
+    /*
+     * @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js
+     */
+    expanded (newValue, oldValue) {
+      if (newValue !== oldValue) {
+        if (newValue === true) {
+          // unbound
+          // @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js#L33
+          this.$refs.collapse.style.setProperty('--collapse-max-height', 'none')
+        }
+        // We need to wait for the next RAF to be sure the CSS variable will be set
+        // DSFR use RAF too https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/api/modules/render/renderer.js#L22
+        window.requestAnimationFrame(() => {
+          this.collapsing = true
+          this.adjust()
+          // We need to wait for the next RAF to be sure the animation will be triggered
+          window.requestAnimationFrame(() => {
+            this.cssExpanded = newValue
+          })
+        })
+      }
+    },
+  },
+
+  methods: {
+    /*
+     * @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js#L61
+     */
+    adjust () {
+      this.$refs.collapse.style.setProperty('--collapser', 'none')
+      const height = this.$refs.collapse.offsetHeight
+      this.$refs.collapse.style.setProperty('--collapse', -height + 'px')
+      this.$refs.collapse.style.setProperty('--collapser', '')
+    },
+    /*
+     * @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js#L25
+     */
+    onTransitionEnd () {
+      this.collapsing = false
+      if (this.expanded === false) {
+        this.$refs.collapse.style.removeProperty('--collapse-max-height')
+      }
+    },
   },
 })
 </script>
@@ -37,18 +86,23 @@ export default defineComponent({
     aria-label="vous êtes ici :"
   >
     <button
-      v-show="!hideButton"
+      v-show="!expanded"
       class="fr-breadcrumb__button"
-      :aria-expanded="hideButton"
+      :aria-expanded="expanded"
       :aria-controls="breadcrumbId"
-      @click="hideButton = !hideButton"
+      @click="expanded = !expanded"
     >
       Voir le fil d’Ariane
     </button>
     <div
       :id="breadcrumbId"
+      ref="collapse"
       class="fr-collapse"
-      :class="{ 'fr-collapse--expanded': hideButton }"
+      :class="{
+        'fr-collapse--expanded': cssExpanded, // Need to use a separate data to add/remove the class after a RAF
+        'fr-collapsing': collapsing,
+      }"
+      @transitionend="onTransitionEnd"
     >
       <ol class="fr-breadcrumb__list">
         <li

--- a/src/components/DsfrBreadcrumb/DsfrBreadcrumb.vue
+++ b/src/components/DsfrBreadcrumb/DsfrBreadcrumb.vue
@@ -1,10 +1,7 @@
 <script>
 import { defineComponent } from 'vue'
-
-// Ne fonctionne pas dans Nuxt
-// import '@gouvfr/dsfr/dist/component/breadcrumb/breadcrumb.module.js'
-
 import { getRandomId } from '../../utils/random-utils.js'
+import { useCollapsable } from '@/composables'
 
 export default defineComponent({
   name: 'DsfrBreadcrumb',
@@ -22,11 +19,28 @@ export default defineComponent({
     },
   },
 
+  setup () {
+    const {
+      collapse,
+      collapsing,
+      cssExpanded,
+      doExpand,
+      adjust,
+      onTransitionEnd,
+    } = useCollapsable()
+
+    return {
+      collapse,
+      collapsing,
+      cssExpanded,
+      doExpand,
+      adjust,
+      onTransitionEnd,
+    }
+  },
+
   data () {
     return {
-      collapsing: false,
-      // Need to handle a separate data to add/remove the class after a RAF
-      cssExpanded: false,
       expanded: false,
     }
   },
@@ -37,42 +51,7 @@ export default defineComponent({
      */
     expanded (newValue, oldValue) {
       if (newValue !== oldValue) {
-        if (newValue === true) {
-          // unbound
-          // @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js#L33
-          this.$refs.collapse.style.setProperty('--collapse-max-height', 'none')
-        }
-        // We need to wait for the next RAF to be sure the CSS variable will be set
-        // DSFR use RAF too https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/api/modules/render/renderer.js#L22
-        window.requestAnimationFrame(() => {
-          this.collapsing = true
-          this.adjust()
-          // We need to wait for the next RAF to be sure the animation will be triggered
-          window.requestAnimationFrame(() => {
-            this.cssExpanded = newValue
-          })
-        })
-      }
-    },
-  },
-
-  methods: {
-    /*
-     * @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js#L61
-     */
-    adjust () {
-      this.$refs.collapse.style.setProperty('--collapser', 'none')
-      const height = this.$refs.collapse.offsetHeight
-      this.$refs.collapse.style.setProperty('--collapse', -height + 'px')
-      this.$refs.collapse.style.setProperty('--collapser', '')
-    },
-    /*
-     * @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js#L25
-     */
-    onTransitionEnd () {
-      this.collapsing = false
-      if (this.expanded === false) {
-        this.$refs.collapse.style.removeProperty('--collapse-max-height')
+        this.doExpand(newValue)
       }
     },
   },
@@ -102,7 +81,7 @@ export default defineComponent({
         'fr-collapse--expanded': cssExpanded, // Need to use a separate data to add/remove the class after a RAF
         'fr-collapsing': collapsing,
       }"
-      @transitionend="onTransitionEnd"
+      @transitionend="onTransitionEnd(expanded)"
     >
       <ol class="fr-breadcrumb__list">
         <li

--- a/src/components/DsfrLanguageSelector/DsfrLanguageSelector.vue
+++ b/src/components/DsfrLanguageSelector/DsfrLanguageSelector.vue
@@ -94,7 +94,7 @@ export default defineComponent({
   >
     <div class="fr-nav__item">
       <button
-        class="fr-translate__btn  fr-btn  fr-btn--tertiary"
+        class="fr-translate__btn fr-btn fr-btn--tertiary"
         :aria-controls="id"
         :aria-expanded="expanded"
         title="Sélectionner une langue"
@@ -108,6 +108,7 @@ export default defineComponent({
         ref="collapse"
         class="fr-collapse fr-translate__menu fr-menu"
         :class="{ 'fr-collapse--expanded': cssExpanded, 'fr-collapsing': collapsing }"
+        @transitionend="onTransitionEnd"
       >
         <ul class="fr-menu__list">
           <li

--- a/src/components/DsfrLanguageSelector/DsfrLanguageSelector.vue
+++ b/src/components/DsfrLanguageSelector/DsfrLanguageSelector.vue
@@ -2,6 +2,7 @@
 import { defineComponent } from 'vue'
 
 import { getRandomId } from '../../utils/random-utils.js'
+import { useCollapsable } from '@/composables'
 
 export default defineComponent({
   name: 'DsfrLanguageSelector',
@@ -22,12 +23,28 @@ export default defineComponent({
     },
   },
   emits: ['select'],
+  setup () {
+    const {
+      collapse,
+      collapsing,
+      cssExpanded,
+      doExpand,
+      adjust,
+      onTransitionEnd,
+    } = useCollapsable()
+
+    return {
+      collapse,
+      collapsing,
+      cssExpanded,
+      doExpand,
+      adjust,
+      onTransitionEnd,
+    }
+  },
   data () {
     return {
       expanded: false,
-      collapsing: false,
-      // Need to handle a separate data to add/remove the class after a RAF
-      cssExpanded: false,
     }
   },
   computed: {
@@ -41,21 +58,7 @@ export default defineComponent({
      */
     expanded (newValue, oldValue) {
       if (newValue !== oldValue) {
-        if (newValue === true) {
-          // unbound
-          // @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js#L33
-          this.$refs.collapse.style.setProperty('--collapse-max-height', 'none')
-        }
-        // We need to wait for the next RAF to be sure the CSS variable will be set
-        // DSFR use RAF too https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/api/modules/render/renderer.js#L22
-        window.requestAnimationFrame(() => {
-          this.collapsing = true
-          this.adjust()
-          // We need to wait for the next RAF to be sure the animation will be triggered
-          window.requestAnimationFrame(() => {
-            this.cssExpanded = newValue
-          })
-        })
+        this.doExpand(newValue)
       }
     },
   },
@@ -63,24 +66,6 @@ export default defineComponent({
     selectLanguage (language) {
       this.expanded = false
       this.$emit('select', language)
-    },
-    /*
-     * @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js#L61
-     */
-    adjust () {
-      this.$refs.collapse.style.setProperty('--collapser', 'none')
-      const height = this.$refs.collapse.offsetHeight
-      this.$refs.collapse.style.setProperty('--collapse', -height + 'px')
-      this.$refs.collapse.style.setProperty('--collapser', '')
-    },
-    /*
-     * @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js#L25
-     */
-    onTransitionEnd () {
-      this.collapsing = false
-      if (this.expanded === false) {
-        this.$refs.collapse.style.removeProperty('--collapse-max-height')
-      }
     },
   },
 })
@@ -108,7 +93,7 @@ export default defineComponent({
         ref="collapse"
         class="fr-collapse fr-translate__menu fr-menu"
         :class="{ 'fr-collapse--expanded': cssExpanded, 'fr-collapsing': collapsing }"
-        @transitionend="onTransitionEnd"
+        @transitionend="onTransitionEnd(expanded)"
       >
         <ul class="fr-menu__list">
           <li

--- a/src/components/DsfrNavigation/DsfrNavigation.spec.js
+++ b/src/components/DsfrNavigation/DsfrNavigation.spec.js
@@ -179,7 +179,7 @@ describe('DsfrNavigation', () => {
       },
     })
 
-    router.isReady()
+    await router.isReady()
 
     const menuContainer = getByTestId('navigation-menu')
     const menu = getByText(secondMenuTitle)

--- a/src/components/DsfrNavigation/DsfrNavigation.spec.js
+++ b/src/components/DsfrNavigation/DsfrNavigation.spec.js
@@ -194,10 +194,17 @@ describe('DsfrNavigation', () => {
 
     expect(navEl).toHaveClass('fr-nav')
     expect(navEl).toHaveAttribute('aria-label', label)
+
+    // need to wait RAF
+    await (new Promise(resolve => setTimeout(resolve, 100)))
+
     expect(menuContainer).toHaveClass('fr-collapse')
     expect(menuContainer).toHaveClass('fr-collapse--expanded')
 
     await fireEvent.click(megaMenu)
+
+    // need to wait RAF
+    await (new Promise(resolve => setTimeout(resolve, 100)))
 
     expect(menuContainer).toHaveClass('fr-collapse')
     expect(menuContainer).not.toHaveClass('fr-collapse--expanded')
@@ -205,6 +212,9 @@ describe('DsfrNavigation', () => {
 
     await fireEvent.click(menu)
     await fireEvent.click(menuItemEl)
+
+    // need to wait RAF
+    await (new Promise(resolve => setTimeout(resolve, 100)))
 
     expect(megaMenu.parentElement.querySelector('.fr-mega-menu')).not.toHaveClass('fr-collapse--expanded')
     expect(menuContainer).not.toHaveClass('fr-collapse--expanded')

--- a/src/components/DsfrNavigation/DsfrNavigation.vue
+++ b/src/components/DsfrNavigation/DsfrNavigation.vue
@@ -121,8 +121,4 @@ export default defineComponent({
 .fr-nav__list {
   position: relative;
 }
-
-.fr-menu.fr-collapse--expanded {
-  --collapse-max-height: none;
-}
 </style>

--- a/src/components/DsfrNavigation/DsfrNavigationMegaMenu.vue
+++ b/src/components/DsfrNavigation/DsfrNavigationMegaMenu.vue
@@ -41,9 +41,63 @@ export default defineComponent({
 
   emits: ['toggle-id'],
 
+  data () {
+    return {
+      collapsing: false,
+      // Need to handle a separate data to add/remove the class after a RAF
+      cssExpanded: false,
+    }
+  },
+
   computed: {
     expanded () {
       return this.id === this.expandedId
+    },
+  },
+
+  watch: {
+    /*
+     * @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js
+     */
+    expanded (newValue, oldValue) {
+      if (newValue !== oldValue) {
+        if (newValue === true) {
+          // unbound
+          // @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js#L33
+          this.$refs.collapse.style.setProperty('--collapse-max-height', 'none')
+        }
+        // We need to wait for the next RAF to be sure the CSS variable will be set
+        // DSFR use RAF too https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/api/modules/render/renderer.js#L22
+        window.requestAnimationFrame(() => {
+          this.collapsing = true
+          this.adjust()
+          // We need to wait for the next RAF to be sure the animation will be triggered
+          window.requestAnimationFrame(() => {
+            this.cssExpanded = newValue
+          })
+        })
+      }
+    },
+  },
+
+  methods: {
+    /*
+     * @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js#L61
+     */
+    adjust () {
+      this.$refs.collapse.style.setProperty('--collapser', 'none')
+      const height = this.$refs.collapse.offsetHeight
+      this.$refs.collapse.style.setProperty('--collapse', -height + 'px')
+      this.$refs.collapse.style.setProperty('--collapser', '')
+    },
+    /*
+     * @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js#L25
+     */
+    onTransitionEnd () {
+      this.collapsing = false
+      if (this.expanded === false) {
+        this.$refs.collapse.style.removeProperty('--collapse-max-height')
+      }
     },
   },
 })
@@ -63,7 +117,12 @@ export default defineComponent({
     data-testid="mega-menu-wrapper"
     class="fr-collapse fr-mega-menu"
     tabindex="-1"
-    :class="{ 'fr-collapse--expanded': expanded }"
+    ref="collapse"
+    @transitionend="onTransitionEnd"
+    :class="{
+      'fr-collapse--expanded': cssExpanded, // Need to use a separate data to add/remove the class after a RAF
+      'fr-collapsing': collapsing,
+    }"
   >
     <div class="fr-container  fr-container--fluid  fr-container-lg">
       <button

--- a/src/components/DsfrNavigation/DsfrNavigationMenu.vue
+++ b/src/components/DsfrNavigation/DsfrNavigationMenu.vue
@@ -36,9 +36,63 @@ export default defineComponent({
 
   emits: ['toggle-id'],
 
+  data () {
+    return {
+      collapsing: false,
+      // Need to handle a separate data to add/remove the class after a RAF
+      cssExpanded: false,
+    }
+  },
+
   computed: {
     expanded () {
       return this.id === this.expandedId
+    },
+  },
+
+  watch: {
+    /*
+     * @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js
+     */
+    expanded (newValue, oldValue) {
+      if (newValue !== oldValue) {
+        if (newValue === true) {
+          // unbound
+          // @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js#L33
+          this.$refs.collapse.style.setProperty('--collapse-max-height', 'none')
+        }
+        // We need to wait for the next RAF to be sure the CSS variable will be set
+        // DSFR use RAF too https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/api/modules/render/renderer.js#L22
+        window.requestAnimationFrame(() => {
+          this.collapsing = true
+          this.adjust()
+          // We need to wait for the next RAF to be sure the animation will be triggered
+          window.requestAnimationFrame(() => {
+            this.cssExpanded = newValue
+          })
+        })
+      }
+    },
+  },
+
+  methods: {
+    /*
+     * @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js#L61
+     */
+    adjust () {
+      this.$refs.collapse.style.setProperty('--collapser', 'none')
+      const height = this.$refs.collapse.offsetHeight
+      this.$refs.collapse.style.setProperty('--collapse', -height + 'px')
+      this.$refs.collapse.style.setProperty('--collapser', '')
+    },
+    /*
+     * @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js#L25
+     */
+    onTransitionEnd () {
+      this.collapsing = false
+      if (this.expanded === false) {
+        this.$refs.collapse.style.removeProperty('--collapse-max-height')
+      }
     },
   },
 })
@@ -55,9 +109,11 @@ export default defineComponent({
   </button>
   <div
     :id="id"
+    ref="collapse"
     class="fr-collapse fr-menu"
     data-testid="navigation-menu"
-    :class="{ 'fr-collapse--expanded': expanded }"
+    :class="{ 'fr-collapse--expanded': cssExpanded, 'fr-collapsing': collapsing }"
+    @transitionend="onTransitionEnd"
   >
     <ul class="fr-menu__list">
       <!-- @slot Slot par défaut pour le contenu de l’item de liste. Sera dans `<ul class="fr-menu__list">` -->

--- a/src/components/DsfrSideMenu/DsfrSideMenu.stories.js
+++ b/src/components/DsfrSideMenu/DsfrSideMenu.stories.js
@@ -1,4 +1,7 @@
 import DsfrSideMenu from './DsfrSideMenu.vue'
+import DsfrAccordion from '../DsfrAccordion/DsfrAccordion.vue'
+import DsfrAccordionsGroup from '../DsfrAccordion/DsfrAccordionsGroup.vue'
+import DsfrCheckboxSet from '../DsfrCheckbox/DsfrCheckboxSet.vue'
 
 function toggleExpandedForMenuWithId (menuItems, id) {
   menuItems.forEach(menuItem => {
@@ -109,4 +112,73 @@ MenuLateral.args = {
       ],
     },
   ],
+}
+
+export const MenuLateralAvecAccordeonEtCheckbox = (args) => ({
+  components: {
+    DsfrSideMenu,
+    DsfrAccordion,
+    DsfrAccordionsGroup,
+    DsfrCheckboxSet,
+  },
+
+  data () {
+    return {
+      ...args,
+      expandedId: undefined,
+      accordions: args.accordions,
+    }
+  },
+
+  template: `
+    <dsfr-side-menu
+      heading-title="Filtres"
+      button-label="Afficher les filtres"
+    >
+      <dsfr-accordions-group>
+        <li
+          v-for="(accordion, name) in accordions"
+          :id="\`accordion_${name}\`"
+          :key="name"
+        >
+          <dsfr-accordion
+            :id="name"
+            :title="name"
+            :expanded-id="expandedId"
+            @expand="id => expandedId = id"
+          >
+            <dsfr-checkbox-set
+              :options="accordion.options"
+              small
+            />
+          </dsfr-accordion>
+        </li>
+      </dsfr-accordions-group>
+    </dsfr-side-menu>
+  `,
+})
+MenuLateralAvecAccordeonEtCheckbox.args = {
+  accordions: {
+    'Accordéon 1': {
+      options: [
+        { label: 'Option 1', value: 'option1' },
+        { label: 'Option 2', value: 'option2' },
+        { label: 'Option 3', value: 'option3' },
+      ],
+    },
+    'Accordéon 2': {
+      options: [
+        { label: 'Option 1', value: 'option1' },
+        { label: 'Option 2', value: 'option2' },
+        { label: 'Option 3', value: 'option3' },
+      ],
+    },
+    'Accordéon 3': {
+      options: [
+        { label: 'Option 1', value: 'option1' },
+        { label: 'Option 2', value: 'option2' },
+        { label: 'Option 3', value: 'option3' },
+      ],
+    },
+  },
 }

--- a/src/components/DsfrSideMenu/DsfrSideMenu.stories.js
+++ b/src/components/DsfrSideMenu/DsfrSideMenu.stories.js
@@ -161,23 +161,23 @@ MenuLateralAvecAccordeonEtCheckbox.args = {
   accordions: {
     'Accordéon 1': {
       options: [
-        { label: 'Option 1', value: 'option1' },
-        { label: 'Option 2', value: 'option2' },
-        { label: 'Option 3', value: 'option3' },
+        { label: 'Option 1', value: 'option1', name: 'option1' },
+        { label: 'Option 2', value: 'option2', name: 'option2' },
+        { label: 'Option 3', value: 'option3', name: 'option3' },
       ],
     },
     'Accordéon 2': {
       options: [
-        { label: 'Option 1', value: 'option1' },
-        { label: 'Option 2', value: 'option2' },
-        { label: 'Option 3', value: 'option3' },
+        { label: 'Option 1', value: 'option1', name: 'option1' },
+        { label: 'Option 2', value: 'option2', name: 'option2' },
+        { label: 'Option 3', value: 'option3', name: 'option3' },
       ],
     },
     'Accordéon 3': {
       options: [
-        { label: 'Option 1', value: 'option1' },
-        { label: 'Option 2', value: 'option2' },
-        { label: 'Option 3', value: 'option3' },
+        { label: 'Option 1', value: 'option1', name: 'option1' },
+        { label: 'Option 2', value: 'option2', name: 'option2' },
+        { label: 'Option 3', value: 'option3', name: 'option3' },
       ],
     },
   },

--- a/src/components/DsfrSideMenu/DsfrSideMenuList.vue
+++ b/src/components/DsfrSideMenu/DsfrSideMenuList.vue
@@ -30,6 +30,8 @@ export default defineComponent({
   data () {
     return {
       collapsing: false,
+      // Need to handle a separate data to add/remove the class after a RAF
+      cssExpanded: false,
     }
   },
 
@@ -44,8 +46,16 @@ export default defineComponent({
           // @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js#L33
           this.$refs.collapse.style.setProperty('--collapse-max-height', 'none')
         }
-        this.collapsing = true
-        this.adjust()
+        // We need to wait for the next RAF to be sure the CSS variable will be set
+        // DSFR use RAF too https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/api/modules/render/renderer.js#L22
+        window.requestAnimationFrame(() => {
+          this.collapsing = true
+          this.adjust()
+          // We need to wait for the next RAF to be sure the animation will be triggered
+          window.requestAnimationFrame(() => {
+            this.cssExpanded = newValue
+          })
+        })
       }
     },
   },
@@ -89,7 +99,7 @@ export default defineComponent({
     :class="{
       'fr-collapse': collapsable,
       'fr-collapsing': collapsing,
-      'fr-collapse--expanded': expanded
+      'fr-collapse--expanded': cssExpanded
     }"
     @transitionend="onTransitionEnd"
   >

--- a/src/components/DsfrSideMenu/DsfrSideMenuList.vue
+++ b/src/components/DsfrSideMenu/DsfrSideMenuList.vue
@@ -84,6 +84,7 @@ export default defineComponent({
 
 <template>
   <div
+    :id="id"
     ref="collapse"
     :class="{
       'fr-collapse': collapsable,
@@ -93,7 +94,6 @@ export default defineComponent({
     @transitionend="onTransitionEnd"
   >
     <ul
-      :id="id"
       class="fr-sidemenu__list"
     >
       <!-- @slot Slot par défaut pour le contenu d’une liste du menu latéral -->
@@ -136,3 +136,14 @@ export default defineComponent({
     </ul>
   </div>
 </template>
+
+<style lang="css">
+/* Missing in DSFR */
+.fr-sidemenu .fr-accordion .fr-collapse {
+  padding: 0 1rem 0 1rem;
+}
+.fr-sidemenu .fr-accordion .fr-collapse--expanded {
+  padding-bottom: 0;
+  padding-top: 0;
+}
+</style>

--- a/src/components/DsfrSideMenu/DsfrSideMenuList.vue
+++ b/src/components/DsfrSideMenu/DsfrSideMenuList.vue
@@ -3,6 +3,7 @@ import { defineComponent } from 'vue'
 
 import DsfrSideMenuListItem from './DsfrSideMenuListItem.vue'
 import DsfrSideMenuButton from './DsfrSideMenuButton.vue'
+import { useCollapsable } from '@/composables'
 
 export default defineComponent({
   name: 'DsfrSideMenuList',
@@ -27,11 +28,23 @@ export default defineComponent({
 
   emits: ['toggle-expand'],
 
-  data () {
+  setup () {
+    const {
+      collapse,
+      collapsing,
+      cssExpanded,
+      doExpand,
+      adjust,
+      onTransitionEnd,
+    } = useCollapsable()
+
     return {
-      collapsing: false,
-      // Need to handle a separate data to add/remove the class after a RAF
-      cssExpanded: false,
+      collapse,
+      collapsing,
+      cssExpanded,
+      doExpand,
+      adjust,
+      onTransitionEnd,
     }
   },
 
@@ -41,23 +54,17 @@ export default defineComponent({
      */
     expanded (newValue, oldValue) {
       if (newValue !== oldValue) {
-        if (newValue === true) {
-          // unbound
-          // @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js#L33
-          this.$refs.collapse.style.setProperty('--collapse-max-height', 'none')
-        }
-        // We need to wait for the next RAF to be sure the CSS variable will be set
-        // DSFR use RAF too https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/api/modules/render/renderer.js#L22
-        window.requestAnimationFrame(() => {
-          this.collapsing = true
-          this.adjust()
-          // We need to wait for the next RAF to be sure the animation will be triggered
-          window.requestAnimationFrame(() => {
-            this.cssExpanded = newValue
-          })
-        })
+        this.doExpand(newValue)
       }
     },
+  },
+
+  mounted () {
+    // Accordion can be expanded by default
+    // We need to trigger the expand animation at mounted
+    if (this.expanded) {
+      this.doExpand(true)
+    }
   },
 
   methods: {
@@ -69,24 +76,6 @@ export default defineComponent({
     },
     linkProps (to) {
       return { [this.isExternalLink(to) ? 'href' : 'to']: to }
-    },
-    /*
-     * @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js#L61
-     */
-    adjust () {
-      this.$refs.collapse.style.setProperty('--collapser', 'none')
-      const height = this.$refs.collapse.offsetHeight
-      this.$refs.collapse.style.setProperty('--collapse', -height + 'px')
-      this.$refs.collapse.style.setProperty('--collapser', '')
-    },
-    /*
-     * @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js#L25
-     */
-    onTransitionEnd () {
-      this.collapsing = false
-      if (this.expanded === false) {
-        this.$refs.collapse.style.removeProperty('--collapse-max-height')
-      }
     },
   },
 })
@@ -101,7 +90,7 @@ export default defineComponent({
       'fr-collapsing': collapsing,
       'fr-collapse--expanded': cssExpanded
     }"
-    @transitionend="onTransitionEnd"
+    @transitionend="onTransitionEnd(expanded)"
   >
     <ul
       class="fr-sidemenu__list"

--- a/src/components/DsfrSideMenu/DsfrSideMenuList.vue
+++ b/src/components/DsfrSideMenu/DsfrSideMenuList.vue
@@ -27,6 +27,29 @@ export default defineComponent({
 
   emits: ['toggle-expand'],
 
+  data () {
+    return {
+      collapsing: false,
+    }
+  },
+
+  watch: {
+    /*
+     * @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js
+     */
+    expanded (newValue, oldValue) {
+      if (newValue !== oldValue) {
+        if (newValue === true) {
+          // unbound
+          // @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js#L33
+          this.$refs.collapse.style.setProperty('--collapse-max-height', 'none')
+        }
+        this.collapsing = true
+        this.adjust()
+      }
+    },
+  },
+
   methods: {
     isExternalLink (to) {
       return typeof to === 'string' && to.startsWith('http')
@@ -37,61 +60,79 @@ export default defineComponent({
     linkProps (to) {
       return { [this.isExternalLink(to) ? 'href' : 'to']: to }
     },
+    /*
+     * @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js#L61
+     */
+    adjust () {
+      this.$refs.collapse.style.setProperty('--collapser', 'none')
+      const height = this.$refs.collapse.offsetHeight
+      this.$refs.collapse.style.setProperty('--collapse', -height + 'px')
+      this.$refs.collapse.style.setProperty('--collapser', '')
+    },
+    /*
+     * @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js#L25
+     */
+    onTransitionEnd () {
+      this.collapsing = false
+      if (this.expanded === false) {
+        this.$refs.collapse.style.removeProperty('--collapse-max-height')
+      }
+    },
   },
 })
 </script>
 
 <template>
-  <ul
-    :id="id"
-    class="fr-sidemenu__list"
+  <div
+    ref="collapse"
     :class="{
       'fr-collapse': collapsable,
+      'fr-collapsing': collapsing,
       'fr-collapse--expanded': expanded
     }"
+    @transitionend="onTransitionEnd"
   >
-    <!-- @slot Slot par défaut pour le contenu d’une liste du menu latéral -->
-    <slot />
-
-    <DsfrSideMenuListItem
-      v-for="(menuItem, i) of menuItems"
-      :key="i"
-      :active="menuItem.active"
+    <ul
+      :id="id"
+      class="fr-sidemenu__list"
     >
-      <component
-        :is="is(menuItem.to)"
-        v-if="!menuItem.menuItems"
-        class="fr-sidemenu__link"
-        :aria-current="menuItem.active ? 'page' : undefined"
-        v-bind="linkProps(menuItem.to)"
-      >
-        {{ menuItem.text }}
-      </component>
+      <!-- @slot Slot par défaut pour le contenu d’une liste du menu latéral -->
+      <slot />
 
-      <template v-if="menuItem.menuItems">
-        <DsfrSideMenuButton
-          :active="!!menuItem.active"
-          :expanded="!!menuItem.expanded"
-          :control-id="menuItem.id"
-          @toggle-expand="$emit('toggle-expand', $event)"
+      <DsfrSideMenuListItem
+        v-for="(menuItem, i) of menuItems"
+        :key="i"
+        :active="menuItem.active"
+      >
+        <component
+          :is="is(menuItem.to)"
+          v-if="!menuItem.menuItems"
+          class="fr-sidemenu__link"
+          :aria-current="menuItem.active ? 'page' : undefined"
+          v-bind="linkProps(menuItem.to)"
         >
           {{ menuItem.text }}
-        </DsfrSideMenuButton>
-        <DsfrSideMenuList
-          v-if="menuItem.menuItems"
-          :id="menuItem.id"
-          :collapsable="true"
-          :expanded="menuItem.expanded"
-          :menu-items="menuItem.menuItems"
-          @toggle-expand="$emit('toggle-expand', $event)"
-        />
-      </template>
-    </DsfrSideMenuListItem>
-  </ul>
-</template>
+        </component>
 
-<style>
-.fr-collapse--expanded {
-  max-height: none;
-}
-</style>
+        <template v-if="menuItem.menuItems">
+          <DsfrSideMenuButton
+            :active="!!menuItem.active"
+            :expanded="!!menuItem.expanded"
+            :control-id="menuItem.id"
+            @toggle-expand="$emit('toggle-expand', $event)"
+          >
+            {{ menuItem.text }}
+          </DsfrSideMenuButton>
+          <DsfrSideMenuList
+            v-if="menuItem.menuItems"
+            :id="menuItem.id"
+            collapsable
+            :expanded="menuItem.expanded"
+            :menu-items="menuItem.menuItems"
+            @toggle-expand="$emit('toggle-expand', $event)"
+          />
+        </template>
+      </DsfrSideMenuListItem>
+    </ul>
+  </div>
+</template>

--- a/src/components/DsfrTabs/DsfrTabs.stories.ts
+++ b/src/components/DsfrTabs/DsfrTabs.stories.ts
@@ -191,9 +191,9 @@ export const OngletsComplexes = (args) => ({
     },
   },
 
-
 })
 OngletsComplexes.args = {
+  tabContents: [],
   tabListName,
   tabTitles: customTabTitles,
   selectedTabIndex: 1,
@@ -274,10 +274,9 @@ export const OngletsAvecAccordeon = (args) => ({
       this.selectedTabIndex = idx
     },
   },
-
-
 })
 OngletsAvecAccordeon.args = {
+  tabContents: [],
   tabListName,
   tabTitles: [
     { title: 'Onglet avec accordéon', icon: 'ri-checkbox-circle-line', tabId: 'tab-0', panelId: 'tab-content-0' },
@@ -288,5 +287,5 @@ OngletsAvecAccordeon.args = {
   title1: 'Un titre d’accordéon 1',
   title2: 'Un titre d’accordéon 2',
   title3: 'Un titre d’accordéon 3',
-  expandedId: '',
+  expandedId: undefined,
 }

--- a/src/components/DsfrTabs/DsfrTabs.vue
+++ b/src/components/DsfrTabs/DsfrTabs.vue
@@ -162,8 +162,8 @@ export default defineComponent({
     <DsfrTabContent
       v-for="(tabContent, index) in tabContents"
       :key="index"
-      :panel-id="tabTitles[index].panelId || `${getIdFromIndex(index)}-panel`"
-      :tab-id="tabTitles[index].tabId || getIdFromIndex(index)"
+      :panel-id="tabTitles?.[index]?.panelId || `${getIdFromIndex(index)}-panel`"
+      :tab-id="tabTitles?.[index]?.tabId || getIdFromIndex(index)"
       :selected="isSelected(index)"
       :asc="asc"
     >

--- a/src/components/DsfrTranscription/DsfrTranscription.stories.js
+++ b/src/components/DsfrTranscription/DsfrTranscription.stories.js
@@ -43,5 +43,4 @@ export const Transcription = (args) => ({
 Transcription.args = {
   title: 'Chats hiver',
   content: 'Des chatons jouant dans la neige',
-  collapseValue: '-114px',
 }

--- a/src/components/DsfrTranscription/DsfrTranscription.stories.js
+++ b/src/components/DsfrTranscription/DsfrTranscription.stories.js
@@ -24,10 +24,6 @@ export default {
       control: 'text',
       description: 'Transcription du contenu de la vidéo',
     },
-    collapseValue: {
-      control: 'text',
-      description: 'Valeur en pixels de la hauteur de dépliement de la transcription',
-    },
   },
 }
 
@@ -40,7 +36,6 @@ export const Transcription = (args) => ({
     <DsfrTranscription
       :title="title"
       :content="content"
-      :collapseValue="collapseValue"
     />
   `,
 

--- a/src/components/DsfrTranscription/DsfrTranscription.vue
+++ b/src/components/DsfrTranscription/DsfrTranscription.vue
@@ -98,6 +98,7 @@ export default defineComponent({
       ref="collapse"
       class="fr-collapse"
       :class="{ 'fr-collapse--expanded': cssExpanded, 'fr-collapsing': collapsing }"
+      @transitionend="onTransitionEnd"
     >
       <dialog
         :id="modalId"

--- a/src/composables.js
+++ b/src/composables.js
@@ -38,6 +38,9 @@ export const useCollapsable = () => {
    * @return void
    */
   const adjust = () => {
+    if (!collapse.value) {
+      return
+    }
     collapse.value.style.setProperty('--collapser', 'none')
     const height = collapse.value.offsetHeight
     collapse.value.style.setProperty('--collapse', -height + 'px')
@@ -49,6 +52,9 @@ export const useCollapsable = () => {
    * @return void
    */
   const doExpand = (newValue) => {
+    if (!collapse.value) {
+      return
+    }
     if (newValue === true) {
       // unbound
       // @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js#L33

--- a/src/composables.js
+++ b/src/composables.js
@@ -22,6 +22,72 @@ const getThemeMatchingScheme = (scheme, mediaQuery) => {
   return scheme
 }
 
+/*
+ * Reproduce the DSFR fr-collapse behavior
+ */
+export const useCollapsable = () => {
+  /** @type {Ref<HTMLElement>} */
+  const collapse = ref()
+  /** @type {Ref<boolean>} */
+  const collapsing = ref(false)
+  /** @type {Ref<boolean>} */
+  const cssExpanded = ref(false)
+
+  /**
+   * @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js#L61
+   * @return void
+   */
+  const adjust = () => {
+    collapse.value.style.setProperty('--collapser', 'none')
+    const height = collapse.value.offsetHeight
+    collapse.value.style.setProperty('--collapse', -height + 'px')
+    collapse.value.style.setProperty('--collapser', '')
+  }
+
+  /**
+   * @param {boolean} newValue
+   * @return void
+   */
+  const doExpand = (newValue) => {
+    if (newValue === true) {
+      // unbound
+      // @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js#L33
+      collapse.value.style.setProperty('--collapse-max-height', 'none')
+    }
+    // We need to wait for the next RAF to be sure the CSS variable will be set
+    // DSFR use RAF too https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/api/modules/render/renderer.js#L22
+    window.requestAnimationFrame(() => {
+      collapsing.value = true
+      adjust()
+      // We need to wait for the next RAF to be sure the animation will be triggered
+      window.requestAnimationFrame(() => {
+        cssExpanded.value = newValue
+      })
+    })
+  }
+
+  /**
+   * @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js#L25
+   * @param {boolean} expanded
+   * @return void
+   */
+  const onTransitionEnd = (expanded) => {
+    collapsing.value = false
+    if (collapse.value && expanded === false) {
+      collapse.value.style.removeProperty('--collapse-max-height')
+    }
+  }
+
+  return {
+    collapse,
+    collapsing,
+    cssExpanded,
+    doExpand,
+    adjust,
+    onTransitionEnd,
+  }
+}
+
 /**
  *
  * @param {import('../types/composables.js').UseThemeOptions=} options

--- a/types/components/DsfrTranscription/DsfrTranscription.vue.d.ts
+++ b/types/components/DsfrTranscription/DsfrTranscription.vue.d.ts
@@ -7,10 +7,6 @@ declare const _default: import('vue').DefineComponent<{
         type: StringConstructor;
         default: string;
     };
-    collapseValue: {
-        type: StringConstructor;
-        default: string;
-    };
 }, unknown, {
     opened: boolean;
     expanded: boolean;
@@ -27,13 +23,8 @@ declare const _default: import('vue').DefineComponent<{
         type: StringConstructor;
         default: string;
     };
-    collapseValue: {
-        type: StringConstructor;
-        default: string;
-    };
 }>>, {
     content: string;
     title: string;
-    collapseValue: string;
 }>
 export default _default


### PR DESCRIPTION
I've created an example in which collapsable animation does not perform well.

- Single accordion perform pretty well
- Nested accordion sort of well-ish
- SideMenu does not animate at all
- Accordion in SideMenu animation is bouncy

I'll try to implement vanilla DSFR JS code to these components using `@transitionend` to reset CSS vars.

I don't know how to get super smooth CSS anims like on React DSFR https://react-dsfr-components.etalab.studio/?path=/docs/components-sidemenu--side-menu-with-2-levels