### PR TITLE
fix(DsfrCard): Fixed horizontal feature, added external link, buttons and links-group features

### DIFF
--- a/src/components/DsfrCard/DsfrCard.stories.js
+++ b/src/components/DsfrCard/DsfrCard.stories.js
@@ -31,6 +31,14 @@ export default {
       control: 'text',
       description: 'URL cible de la carte',
     },
+    buttons: {
+      control: 'object',
+      description: 'Tableau d’objets (`label` et `link`), chaque objet contiendra les props à passer à DsfrButtonGroup',
+    },
+    linksGroup: {
+      control: 'object',
+      description: 'Tableau d’objets (`label` et `href`), chaque objet contiendra les props pour chaque lien',
+    },
     title: {
       control: 'text',
       description: 'Titre de la carte',
@@ -38,6 +46,11 @@ export default {
     horizontal: {
       control: 'boolean',
       description: 'Indique si le contenu de la carte doit être horizontal (passe de toute façon en vertical sur mobile)',
+    },
+    size: {
+      control: 'radio',
+      options: ['small', 'medium', 'large'],
+      description: 'Indique la taille de la carte',
     },
     titleTag: {
       control: 'text',
@@ -57,8 +70,10 @@ export const Card = (args) => ({
       :alt-img="altImg"
       :detail="detail"
       :description="description"
+      :buttons="buttons"
       :img-src="imgSrc"
       :link="link"
+      :size="size"
       :title="title"
       :horizontal="horizontal"
       :no-arrow="noArrow"
@@ -77,6 +92,9 @@ Card.args = {
   titleTag: undefined,
   noArrow: false,
   horizontal: false,
+  size: 'medium',
+  buttons: [],
+  linksGroup: [],
 }
 
 export const CardSansFleche = (args) => ({
@@ -89,9 +107,11 @@ export const CardSansFleche = (args) => ({
       :style="\`max-width: \${horizontal ? 600 : 400}px\`"
       :alt-img="altImg"
       :detail="detail"
+      :buttons="buttons"
       :description="description"
       :img-src="imgSrc"
       :link="link"
+      :size="size"
       :title="title"
       :horizontal="horizontal"
       :no-arrow="noArrow"
@@ -108,4 +128,182 @@ CardSansFleche.args = {
   title: 'Qu’est-ce que le Pass Culture et comment l’obtenir ?',
   noArrow: true,
   horizontal: false,
+  size: 'medium',
+  buttons: [],
+  linksGroup: [],
+}
+
+export const CardAvecBoutons = (args) => ({
+  components: { DsfrCard },
+  data () {
+    return args
+  },
+  template: `
+    <DsfrCard
+      :style="\`max-width: \${horizontal ? 600 : 400}px\`"
+      :alt-img="altImg"
+      :detail="detail"
+      :buttons="buttons"
+      :description="description"
+      :img-src="imgSrc"
+      :link="link"
+      :size="size"
+      :title="title"
+      :horizontal="horizontal"
+      :no-arrow="noArrow"
+    />
+  `,
+
+})
+CardAvecBoutons.args = {
+  altImg: '',
+  detail: 'Détails sur la carte en question',
+  description: 'Description sommaire de la carte',
+  imgSrc: 'https://placekitten.com/300/200',
+  link: undefined,
+  title: 'Qu’est-ce que le Pass Culture et comment l’obtenir ?',
+  noArrow: true,
+  horizontal: false,
+  buttons: [
+    {
+      label: 'Télécharger',
+      link: 'https://www.systeme-de-design.gouv.fr/',
+    },
+    {
+      label: 'En savoir plus',
+      secondary: true,
+      link: 'https://www.systeme-de-design.gouv.fr/',
+    },
+  ],
+}
+
+export const CardAvecLiens = (args) => ({
+  components: { DsfrCard },
+  data () {
+    return args
+  },
+  template: `
+    <DsfrCard
+      :style="\`max-width: \${horizontal ? 600 : 400}px\`"
+      :alt-img="altImg"
+      :detail="detail"
+      :links-group="linksGroup"
+      :description="description"
+      :img-src="imgSrc"
+      :link="link"
+      :size="size"
+      :title="title"
+      :horizontal="horizontal"
+      :no-arrow="noArrow"
+    />
+  `,
+
+})
+CardAvecLiens.args = {
+  altImg: '',
+  detail: 'Détails sur la carte en question',
+  description: 'Description sommaire de la carte',
+  imgSrc: 'https://placekitten.com/300/200',
+  link: undefined,
+  title: 'Qu’est-ce que le Pass Culture et comment l’obtenir ?',
+  noArrow: true,
+  horizontal: false,
+  linksGroup: [
+    {
+      label: 'Télécharger',
+      href: 'https://www.systeme-de-design.gouv.fr/',
+    },
+    {
+      label: 'En savoir plus',
+      href: 'https://www.systeme-de-design.gouv.fr/',
+    },
+  ],
+}
+
+export const CardHorizontaleAvecBoutons = (args) => ({
+  components: { DsfrCard },
+  data () {
+    return args
+  },
+  template: `
+    <DsfrCard
+      :style="\`max-width: \${horizontal ? 600 : 400}px\`"
+      :alt-img="altImg"
+      :detail="detail"
+      :buttons="buttons"
+      :description="description"
+      :img-src="imgSrc"
+      :link="link"
+      :size="size"
+      :title="title"
+      :horizontal="horizontal"
+      :no-arrow="noArrow"
+    />
+  `,
+
+})
+CardHorizontaleAvecBoutons.args = {
+  altImg: '',
+  detail: 'Détails sur la carte en question',
+  description: 'Description sommaire de la carte',
+  imgSrc: 'https://placekitten.com/300/200',
+  link: undefined,
+  title: 'Qu’est-ce que le Pass Culture et comment l’obtenir ?',
+  noArrow: true,
+  horizontal: true,
+  buttons: [
+    {
+      label: 'Télécharger',
+      link: 'https://www.systeme-de-design.gouv.fr/',
+    },
+    {
+      label: 'En savoir plus',
+      secondary: true,
+      link: 'https://www.systeme-de-design.gouv.fr/',
+    },
+  ],
+}
+
+export const CardHorizontaleEtSmallAvecLiens = (args) => ({
+  components: { DsfrCard },
+  data () {
+    return args
+  },
+  template: `
+    <DsfrCard
+      :style="\`max-width: \${horizontal ? 600 : 400}px\`"
+      :alt-img="altImg"
+      :detail="detail"
+      :links-group="linksGroup"
+      :description="description"
+      :img-src="imgSrc"
+      :link="link"
+      :size="size"
+      :title="title"
+      :horizontal="horizontal"
+      :no-arrow="noArrow"
+    />
+  `,
+
+})
+CardHorizontaleEtSmallAvecLiens.args = {
+  altImg: '',
+  detail: 'Détails sur la carte en question',
+  description: 'Description sommaire de la carte',
+  imgSrc: 'https://placekitten.com/300/200',
+  link: undefined,
+  title: 'Qu’est-ce que le Pass Culture et comment l’obtenir ?',
+  noArrow: true,
+  horizontal: true,
+  size: 'small',
+  linksGroup: [
+    {
+      label: 'Télécharger',
+      href: 'https://www.systeme-de-design.gouv.fr/',
+    },
+    {
+      label: 'En savoir plus',
+      href: 'https://www.systeme-de-design.gouv.fr/',
+    },
+  ],
 }

--- a/src/components/DsfrCard/DsfrCard.vue
+++ b/src/components/DsfrCard/DsfrCard.vue
@@ -1,8 +1,10 @@
 <script>
 import { defineComponent } from 'vue'
+import DsfrButtonGroup from '@/components/DsfrButton/DsfrButtonGroup.vue'
 
 export default defineComponent({
   name: 'DsfrCard',
+  components: { DsfrButtonGroup },
 
   props: {
     imgSrc: {
@@ -21,6 +23,10 @@ export default defineComponent({
       type: String,
       default: 'Simple description',
     },
+    size: {
+      type: String,
+      default: 'md',
+    },
     detail: {
       type: String,
       default: 'details',
@@ -33,13 +39,30 @@ export default defineComponent({
       type: String,
       default: 'h3',
     },
+    buttons: {
+      type: Array,
+      default: () => [],
+    },
+    linksGroup: {
+      type: Array,
+      default: () => [],
+    },
     noArrow: Boolean,
     horizontal: Boolean,
   },
 
-  methods: {
-    goToTargetLink () {
-      this.$refs.title.querySelector('.fr-card__link').click()
+  computed: {
+    sm () {
+      return ['sm', 'small'].includes(this.size)
+    },
+    md () {
+      return ['md', 'medium'].includes(this.size)
+    },
+    lg () {
+      return ['lg', 'large'].includes(this.size)
+    },
+    externalLink () {
+      return typeof this.link === 'string' && this.link.startsWith('http')
     },
   },
 })
@@ -51,42 +74,95 @@ export default defineComponent({
     :class="{
       'fr-card--horizontal': horizontal,
       'fr-enlarge-link': !noArrow,
+      'fr-card--sm': sm,
+      'fr-card--lg': lg,
     }"
     data-testid="fr-card"
-    @click="goToTargetLink"
   >
     <div class="fr-card__body">
-      <component
-        :is="titleTag"
-        ref="title"
-        class="fr-card__title"
-      >
-        <RouterLink
-          :to="link"
-          class="fr-card__link"
-          data-testid="card-link"
-          @click="$event.stopPropagation()"
+      <div class="fr-card__content">
+        <component
+          :is="titleTag"
+          ref="title"
+          class="fr-card__title"
         >
-          {{ title }}
-        </RouterLink>
-      </component>
-      <p class="fr-card__desc">
-        {{ description }}
-      </p>
-      <p class="fr-card__detail">
-        {{ detail }}
-      </p>
-    </div>
-    <div class="fr-card__img">
-      <img
-        :src="imgSrc"
-        class="fr-responsive-img"
-        :alt="altImg"
-        data-testid="card-img"
+          <a
+            v-if="externalLink"
+            :href="link"
+            data-testid="card-link"
+            class="fr-card__link"
+          >{{ title }}</a>
+          <RouterLink
+            v-else-if="link"
+            :to="link"
+            class="fr-card__link"
+            data-testid="card-link"
+            @click="$event.stopPropagation()"
+          >
+            {{ title }}
+          </RouterLink>
+          <template v-else>
+            {{ title }}
+          </template>
+        </component>
+        <p class="fr-card__desc">
+          {{ description }}
+        </p>
+        <p class="fr-card__detail">
+          {{ detail }}
+        </p>
+      </div>
+
+      <div
+        v-if="buttons.length || linksGroup.length"
+        class="fr-card__footer"
       >
-      <!-- L'alternative de l'image (attribut alt) doit à priori rester vide car l'image est illustrative
-        et ne doit pas être restituée aux technologies d’assistance. Vous pouvez toutefois remplir l'alternative si vous
-        estimez qu'elle apporte une information essentielle à la compréhension du contenu non présente dans le texte -->
+        <dsfr-button-group
+          v-if="buttons.length"
+          :buttons="buttons"
+          inline-layout-when="lg"
+          :size="size"
+          reverse
+        />
+        <ul
+          v-if="linksGroup.length"
+          class="fr-links-group"
+        >
+          <li
+            v-for="singleLink in linksGroup"
+            :key="singleLink.link || singleLink.href || singleLink.to"
+          >
+            <a
+              :href="singleLink.link || singleLink.href || singleLink.to"
+              :class="{
+                'fr-link': true,
+                'fr-icon-arrow-right-line': true,
+                'fr-link--icon-right': true,
+                'fr-link--sm': sm,
+                'fr-link--lg': lg,
+              }"
+            >
+              {{ singleLink.label }}
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <div
+      v-if="imgSrc"
+      class="fr-card__header"
+    >
+      <div class="fr-card__img">
+        <img
+          :src="imgSrc"
+          class="fr-responsive-img"
+          :alt="altImg"
+          data-testid="card-img"
+        >
+        <!-- L'alternative de l'image (attribut alt) doit à priori rester vide car l'image est illustrative
+          et ne doit pas être restituée aux technologies d’assistance. Vous pouvez toutefois remplir l'alternative si vous
+          estimez qu'elle apporte une information essentielle à la compréhension du contenu non présente dans le texte -->
+      </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
- Removed useless `goToTargetLink` click event on card itself. Link is handled by a `:before` pseudo-element when `noArrow` prop is enabled
- Fix `horizontal` behaviour
![image](https://github.com/dnum-mi/vue-dsfr/assets/380026/d0411408-d56b-49b4-b31d-401c85bb7fb3)
- Added card sizes
![image](https://github.com/dnum-mi/vue-dsfr/assets/380026/eaa64684-84d7-4176-9bb1-65475075249b)
- Added buttons and links
![image](https://github.com/dnum-mi/vue-dsfr/assets/380026/6fe9909a-4c94-4f9e-95c0-7604facf8429)
![image](https://github.com/dnum-mi/vue-dsfr/assets/380026/759dec86-3e1d-464b-9b82-0313ceb201c4)
![image](https://github.com/dnum-mi/vue-dsfr/assets/380026/a6881b1c-87c5-494f-9552-724e9e39ec96)
![image](https://github.com/dnum-mi/vue-dsfr/assets/380026/7d3a02db-ea97-47e2-9b2e-2f64fdb81bbd)
