### PR TITLE
chore: 🏷️ fix props for DsfrSelect

### DIFF
--- a/src/components/DsfrSelect/DsfrSelect.vue
+++ b/src/components/DsfrSelect/DsfrSelect.vue
@@ -7,6 +7,7 @@ defineOptions({
 })
 
 const props = withDefaults(defineProps<{
+  selectId?: string
   required?: boolean
   disabled?: boolean
   selectId?: string
@@ -14,6 +15,8 @@ const props = withDefaults(defineProps<{
   modelValue?: string | number
   label?: string
   options?:(string | number | { value: string | number, text: string, disabled: boolean })[]
+  successMessage?: string
+  errorMessage?: string
 }>(), {
   selectId: () => getRandomId('select'),
   modelValue: undefined,


### PR DESCRIPTION
Dans la version TS du DsfrSelect, il y a une coquille dans la définition des propriétés. Ainsi le message d'erreur ou de succès ne sont pas injectables par le composant parent.


Exemple :
```ts
  <DsfrSelect
    ref="agentCategorySelect"
    label="Catégorie"
    :model-value="modelValue"
    :required="required"
    :options="categories"
    :error-message="errorMessage"
    @update:model-value="(value:string) => $emit('update:model-value', value)"
  />
```
Ce faisant, les propriétés finissent dans $attrs, exemple:
![image](https://github.com/dnum-mi/vue-dsfr/assets/19285360/237b7d0a-df4d-4615-92e8-5a8b403878df)

# How to fix

Définir les propriétés dans le defineProps pour être aligné avec les defaultValue fournies

