### PR TITLE
feat: ✨ Evolution majeure du composant tuile (DSFR 1.10.0)

### DIFF
--- a/src/components/DsfrTile/DsfrTile.spec.ts
+++ b/src/components/DsfrTile/DsfrTile.spec.ts
@@ -37,7 +37,7 @@ describe('DsfrTile', () => {
     const titleEl = getByText(title)
     const descriptionEl = getByText(description)
 
-    expect(titleEl.parentElement.parentElement.parentElement).not.toHaveClass('fr-tile--horizontal')
+    expect(titleEl.parentElement.parentElement.parentElement.parentNode).not.toHaveClass('fr-tile--horizontal')
     expect(descriptionEl).toHaveClass('fr-tile__desc')
   })
 
@@ -65,7 +65,31 @@ describe('DsfrTile', () => {
     const titleEl = getByText(title)
     const descriptionEl = getByText(description)
 
-    expect(titleEl.parentNode.parentNode.parentNode).toHaveClass('fr-tile--horizontal')
+    expect(titleEl.parentNode.parentNode.parentNode.parentNode).toHaveClass('fr-tile--horizontal')
     expect(descriptionEl).toHaveClass('fr-tile__desc')
+  })
+
+  it('should display a tile with a download link', async () => {
+    const title = 'Titre de la tuile'
+    const imgSrc = 'https://placekitten.com/80/80'
+    const description = 'Lorem ipsum dolor sit amet, consectetur adipiscing, incididunt, ut labore et dol'
+    const download = true
+    const { getByText } = render(DsfrTile, {
+      global: {
+        plugins: [router],
+      },
+      props: {
+        title,
+        imgSrc,
+        description,
+        download,
+        to: 'https://placekitten.com/80/80',
+      },
+    })
+
+    await router.isReady()
+
+    const titleEl = getByText(title)
+    expect(titleEl).toHaveAttribute('download', 'true')
   })
 })

--- a/src/components/DsfrTile/DsfrTile.stories.ts
+++ b/src/components/DsfrTile/DsfrTile.stories.ts
@@ -23,6 +23,13 @@ export default {
       control: 'boolean',
       description: 'Permet le basculement de la tuile en mode horizontal',
     },
+    vertical: {
+      options: ['md', 'lg'],
+      control: {
+        type: 'select',
+      },
+      description: 'Permet le basculement de la tuile en mode vertical, selon la largeur de l\'écran',
+    },
     disabled: {
       control: 'boolean',
       description: 'Permet de rendre la tuile désactivée et non-cliquable',
@@ -35,6 +42,34 @@ export default {
       control: 'text',
       description: 'Permet de choisir la balise contenant le titre de la tuile (h3 par défaut)',
     },
+    download: {
+      control: 'boolean',
+      description: 'Permet de passer la tuile en mode téléchargement'
+    },
+    small: {
+      control: 'boolean',
+      description: 'Permet de basculer la tuile en petit format'
+    },
+    icon: {
+      control: 'boolean',
+      description: 'Permet de désactiver l\'icone associée au lien'
+    },
+    noBorder: {
+      control: 'boolean',
+      description: 'Permet de désactiver la bordure de la tuile'
+    },
+    shadow: {
+      control: 'boolean',
+      description: 'Permet d\'ajouter une ombre à la tuile'
+    },
+    noBackground: {
+      control: 'boolean',
+      description: 'Permet de désactiver la couleur de fond de la tuile'
+    },
+    grey: {
+      control: 'boolean',
+      description: 'Permet de passer le fond de la tuile en gris'
+    }
   },
 }
 
@@ -55,9 +90,17 @@ export const TuileSimple = (args) => ({
       :imgSrc="imgSrc"
       :description="description"
       :horizontal="horizontal"
+      :vertical="vertical"
       :disabled="false"
       :to="to"
       :title-tag="titleTag"
+      :download="download"
+      :small="small"
+      :icon="icon"
+      :no-border="noBorder"
+      :shadow="shadow"
+      :no-background="noBackground"
+      :grey="grey"
     />
   `,
 
@@ -70,4 +113,11 @@ TuileSimple.args = {
   disabled: false,
   to: '#',
   titleTag: 'h2',
+  download: false,
+  small: false,
+  icon: false,
+  noBorder: false,
+  shadow: false,
+  noBackground: false,
+  grey: false,
 }

--- a/src/components/DsfrTile/DsfrTile.vue
+++ b/src/components/DsfrTile/DsfrTile.vue
@@ -8,16 +8,27 @@ export type DsfrTileProps = {
   description?: string
   disabled?: boolean
   horizontal?: boolean
+  vertical?: 'md' | 'lg'
   to?: RouteLocationRaw,
   titleTag?: string
+  download?: boolean
+  small?: boolean
+  icon?: boolean
+  noBorder?: boolean
+  shadow?: boolean
+  noBackground?: boolean
+  grey?: boolean
 }
 
 const props = withDefaults(defineProps<DsfrTileProps>(), {
   title: 'Titre de la tuile',
   imgSrc: undefined,
   description: undefined,
+  horizontal: false,
+  vertical: undefined,
   to: '#',
   titleTag: 'h3',
+  icon: true,
 })
 
 const isExternalLink = computed(() => {
@@ -28,47 +39,63 @@ const isExternalLink = computed(() => {
 <template>
   <div
     class="fr-tile fr-enlarge-link"
-    :class="{
-      'fr-tile--horizontal': horizontal,
+    :class="[{
       'fr-tile--disabled': disabled,
-    }"
+      'fr-tile--sm': small === true,
+      'fr-tile--horizontal': horizontal === true,
+      'fr-tile--vertical': horizontal === false || vertical === 'md' || vertical === 'lg',
+      'fr-tile--vertical@md': vertical === 'md',
+      'fr-tile--vertical@lg': vertical === 'lg',
+      'fr-tile--download': download,
+      'fr-tile--no-icon': icon === false,
+      'fr-tile--no-border': noBorder,
+      'fr-tile--no-background': noBackground,
+      'fr-tile--shadow': shadow,
+      'fr-tile--grey': grey,
+    },]"
   >
     <div class="fr-tile__body">
-      <component
-        :is="titleTag"
-        class="fr-tile__title"
-      >
-        <a
-          v-if="isExternalLink"
-          class="fr-tile__link"
-          target="_blank"
-          :href="disabled ? '' : (to as string)"
-        >{{ title }}</a>
-        <RouterLink
-          v-if="!isExternalLink"
-          class="fr-tile__link so-test"
-          :to="disabled ? '' : to"
+      <div class="fr-tile__content">
+        <component
+          :is="titleTag"
+          class="fr-tile__title"
         >
-          {{ title }}
-        </RouterLink>
-      </component>
-      <p
-        v-if="description"
-        class="fr-tile__desc"
-      >
-        {{ description }}
-      </p>
+          <a
+            v-if="isExternalLink"
+            class="fr-tile__link"
+            target="_blank"
+            :download="download"
+            :href="disabled ? '' : (to as string)"
+          >{{ title }}</a>
+          <RouterLink
+            v-if="!isExternalLink"
+            :download="download"
+            class="fr-tile__link so-test"
+            :to="disabled ? '' : to"
+          >
+            {{ title }}
+          </RouterLink>
+        </component>
+        <p
+          v-if="description"
+          class="fr-tile__desc"
+        >
+          {{ description }}
+        </p>
+      </div>
     </div>
-    <div
-      v-if="imgSrc"
-      class="fr-tile__pictogram"
-    >
-      <img
-        :src="imgSrc"
-        class="fr-responsive-img"
-        alt=""
+    <div class="fr-tile__header">
+      <div
+        v-if="imgSrc"
+        class="fr-tile__pictogram"
       >
-    <!-- L'alternative de l'image (attribut alt) doit à priori rester vide car l'image est illustrative et ne doit pas être restituée aux technologies d’assistance. Vous pouvez toutefois remplir l'alternative si vous estimer qu'elle apporte une information essentielle à la compréhension du contenu non présente dans le texte -->
+        <img
+          :src="imgSrc"
+          class="fr-responsive-img"
+          alt=""
+        >
+      <!-- L'alternative de l'image (attribut alt) doit à priori rester vide car l'image est illustrative et ne doit pas être restituée aux technologies d’assistance. Vous pouvez toutefois remplir l'alternative si vous estimer qu'elle apporte une information essentielle à la compréhension du contenu non présente dans le texte -->
+      </div>
     </div>
   </div>
 </template>

--- a/src/components/DsfrTile/DsfrTiles.spec.ts
+++ b/src/components/DsfrTile/DsfrTiles.spec.ts
@@ -64,7 +64,7 @@ describe('DsfrTiles', () => {
     const titleEl = getByText(title1)
     const descriptionEl = getByText(description1)
 
-    expect(titleEl.parentNode.parentNode.parentNode).not.toHaveClass('fr-tile--horizontal')
+    expect(titleEl.parentNode.parentNode.parentNode.parentNode).not.toHaveClass('fr-tile--horizontal')
     expect(descriptionEl).toHaveClass('fr-tile__desc')
   })
 
@@ -107,7 +107,7 @@ describe('DsfrTiles', () => {
     const titleEl = getByText(title1)
     const descriptionEl = getByText(description2)
 
-    expect(titleEl.parentNode.parentNode.parentNode).toHaveClass('fr-tile--horizontal')
+    expect(titleEl.parentNode.parentNode.parentNode.parentNode).toHaveClass('fr-tile--horizontal')
     expect(descriptionEl).toHaveClass('fr-tile__desc')
   })
   it('should display 1 disabled and 1 enabled tile', async () => {
@@ -147,7 +147,45 @@ describe('DsfrTiles', () => {
 
     const titleEl1 = getByText(title1)
     const titleEl2 = getByText(title2)
-    expect(titleEl1.parentNode.parentNode.parentNode).toHaveClass('fr-tile--disabled')
-    expect(titleEl2.parentNode.parentNode.parentNode).not.toHaveClass('fr-tile--disabled')
+    expect(titleEl1.parentNode.parentNode.parentNode.parentNode).toHaveClass('fr-tile--disabled')
+    expect(titleEl2.parentNode.parentNode.parentNode.parentNode).not.toHaveClass('fr-tile--disabled')
+  })
+
+  it('should display a tile with a download link and one without', async () => {
+    const title1 = 'Titre de la tuile 1'
+    const title2 = 'Titre de la tuile 2'
+    const imgSrc = 'https://placekitten.com/80/80'
+
+    const tiles = [
+      {
+        title: title1,
+        imgSrc,
+        disabled: true,
+        to: '/one',
+        download: true,
+      },
+      {
+        title: title2,
+        imgSrc,
+        to: '/two',
+        download: false,
+      },
+    ]
+
+    const { getByText } = render(DsfrTiles, {
+      global: {
+        plugins: [router],
+      },
+      props: {
+        tiles,
+      },
+    })
+
+    await router.isReady()
+
+    const titleEl1 = getByText(title1)
+    const titleEl2 = getByText(title2)
+    expect(titleEl1).toHaveAttribute('download', "true")
+    expect(titleEl2).toHaveAttribute('download', "false")
   })
 })


### PR DESCRIPTION
Évolution majeure du composant tuile suite aux modifications apportées dans la version 1.10.0 du Dsfr, (https://github.com/GouvernementFR/dsfr/releases/tag/v1.10.0), notamment :
- Ajout de wrapper "fr-tile__content" et "fr-tile__header" pour englober le contenu et l’image
- Ajout de variations (no-background, grey, small, etc.)

J'ai du commit avec --no-verify à cause de l'erreur suivante ```ESLint couldn't determine the plugin "@typescript-eslint" uniquely.```