### PR TITLE
feat: ✨ nouveau slot nommé dans le composant DsfrHeader pour le menu de nav primaire

### DIFF
--- a/src/components/DsfrHeader/DsfrHeader.stories.ts
+++ b/src/components/DsfrHeader/DsfrHeader.stories.ts
@@ -244,9 +244,11 @@ export const EnTeteAvecNavigation = (args, { argTypes }) => ({
       @click="onClickOnLogo"
       @search="onSearch($event)"
     >
-      <DsfrNavigation
-        :nav-items="navItems"
-      />
+      <template #mainnav>
+        <DsfrNavigation
+          :nav-items="navItems"
+        />
+      </template>
     </DsfrHeader>
   `,
 

--- a/src/components/DsfrHeader/DsfrHeader.vue
+++ b/src/components/DsfrHeader/DsfrHeader.vue
@@ -73,7 +73,8 @@ const showSearchModal = () => {
 const onQuickLinkClick = hideModal
 
 const slots = useSlots()
-const isWithSlotOperator = computed(() => slots.operator?.().length || !!props.operatorImgSrc)
+const isWithSlotOperator = computed(() => Boolean(slots.operator?.().length) || !!props.operatorImgSrc)
+const isWithSlotNav = computed(() => Boolean(slots.mainnav))
 
 // eslint-disable-next-line func-call-spacing
 defineEmits<{
@@ -114,7 +115,7 @@ defineEmits<{
                 </slot>
               </div>
               <div
-                v-if="showSearch || quickLinks?.length"
+                v-if="showSearch || isWithSlotNav || quickLinks?.length"
                 class="fr-header__navbar"
               >
                 <button
@@ -127,7 +128,7 @@ defineEmits<{
                   @click.prevent.stop="showSearchModal()"
                 />
                 <button
-                  v-if="quickLinks?.length"
+                  v-if="isWithSlotNav || quickLinks?.length"
                   id="button-menu"
                   class="fr-btn--menu  fr-btn"
                   :data-fr-opened="showMenu"
@@ -204,7 +205,7 @@ defineEmits<{
           </div>
         </div>
         <div
-          v-if="showSearch || (quickLinks && quickLinks.length)"
+          v-if="showSearch || isWithSlotNav || (quickLinks && quickLinks.length)"
           id="header-navigation"
           class="fr-header__menu  fr-modal"
           :class="{ 'fr-modal--opened': modalOpened }"
@@ -233,9 +234,15 @@ defineEmits<{
                 />
               </nav>
             </div>
+            <template v-if="modalOpened">
+              <slot
+                name="mainnav"
+                :hidemodal="hideModal"
+              />
+            </template>
             <div
               v-if="searchModalOpened"
-              class="flex  justify-center  items-center"
+              class="flex justify-center items-center"
             >
               <DsfrSearchBar
                 :model-value="modelValue"
@@ -245,6 +252,16 @@ defineEmits<{
               />
             </div>
           </div>
+        </div>
+        <div
+          v-if="isWithSlotNav && !modalOpened"
+          class="fr-hidden fr-unhidden-lg"
+        >
+          <!-- @slot Slot nommé mainnav pour le menu de navigation principal -->
+          <slot
+            name="mainnav"
+            :hidemodal="hideModal"
+          />
         </div>
         <slot />
       </div>


### PR DESCRIPTION
# Raison

Sauf erreur de ma part, le slot par défaut du composant DsfrHeader ne permet pas d'obtenir le comportement prévu pour le menu de nav primaire.

## Comportement actuel

En dessous de LG, le menu de nav reste sous le header :

<img width="578" alt="Capture d’écran 2023-09-13 à 18 15 07" src="https://github.com/dnum-mi/vue-dsfr/assets/48523123/4fa1da84-068c-4283-8db7-cc6022249a1b">

## Comportement souhaitable

En dessous de LG, quand la modale est fermée, le menu est invisible :
<img width="422" alt="Capture d’écran 2023-09-13 à 18 16 24" src="https://github.com/dnum-mi/vue-dsfr/assets/48523123/92ca6a78-4edc-43a9-befa-1a7a99c0d148">

En dessous de LG, quand la modale est ouverte, le menu de nav se loge sous les quicklinks :

<img width="422" alt="Capture d’écran 2023-09-13 à 18 16 30" src="https://github.com/dnum-mi/vue-dsfr/assets/48523123/d1331e76-0ea5-4eec-a345-17cd441604fe">

## Fonctionnement
Après quelque tâtonnements, j'ai l'impression qu'un slot nommé et présent deux fois dans le composant DsfrHeader est la meilleure façon d'obtenir cet effet. Je ne sais pas si il y a des contre indications à faire ça. J'ai laissé le slot par défaut dans le commit pour retrocompatibilité.

Pour fermer la modale depuis le composant passé dans le slot (par exemple lorsqu'on change de route via le menu de navigation), on peut passer le callback hideModal en tant que prop du slot :
```vue
  <DsfrHeader v-bind="headerProps">
    <template #mainnav="{ hidemodal }">
      <MyNavWrapper @route-change="hidemodal" />
    </template>
  </DsfrHeader>
```