### PR TITLE
fix: 🐛 Les boutons de la modale deviennent inline seulement pour les écrans en dessous de lg

### DIFF
--- a/src/components/DsfrModal/DsfrModal.vue
+++ b/src/components/DsfrModal/DsfrModal.vue
@@ -120,7 +120,7 @@ async function close () {
                 <DsfrButtonGroup
                   align="right"
                   :buttons="actions"
-                  inline
+                  inline-layout-when="large"
                   reverse
                 />
               </div>


### PR DESCRIPTION
https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/modale/