### PR TITLE
fix: :wheelchair: Ne pas utiliser input aria-describedby si description absente du DOM

### DIFF
--- a/src/components/DsfrInput/DsfrInputGroup.vue
+++ b/src/components/DsfrInput/DsfrInputGroup.vue
@@ -23,6 +23,7 @@ const props = withDefaults(defineProps<{
   labelClass: '',
   modelValue: '',
   wrapperClass: '',
+  placeholder: undefined,
   errorMessage: undefined,
   validMessage: undefined,
 })
@@ -50,7 +51,7 @@ const messageClass = computed(() => props.errorMessage ? 'fr-error-text' : 'fr-v
       :is-invalid="!!errorMessage"
       :label="label"
       :hint="hint"
-      :description-id="descriptionId"
+      :description-id="(message && descriptionId) || undefined"
       :label-visible="labelVisible"
       :model-value="modelValue"
       :placeholder="placeholder"


### PR DESCRIPTION
Quand aucun message d'erreur ou de validité n'est passé au composant DsfrInput, l'attribut aria-describedby est ajouté à l'élément input sans qu'aucun label d'id correspondant n'existe dans le DOM.

Cela créé une erreur d'accessibilité dans un outil comme Wave Evaluation tool:

<img width="498" alt="Capture d’écran 2023-09-21 à 10 05 20" src="https://github.com/dnum-mi/vue-dsfr/assets/48523123/0aa3a704-ab86-47a1-a9f8-0338932e7b22">