### PR TITLE
fix: :bug: Hisse le v-if au niveau du lien du logo operateur

### DIFF
--- a/src/components/DsfrFooter/DsfrFooter.vue
+++ b/src/components/DsfrFooter/DsfrFooter.vue
@@ -142,12 +142,12 @@ const aLicenceHref = computed(() => {
             />
           </RouterLink>
           <RouterLink
+            v-if="operatorImgSrc"
             class="fr-footer__brand-link"
             :to="operatorTo"
             :title="operatorLinkText"
           >
             <img
-              v-if="operatorImgSrc"
               class="fr-footer__logo  fr-responsive-img"
               :style="[
                 typeof operatorImgStyle === 'string' ? operatorImgStyle : '',


### PR DESCRIPTION
Le lien du logo opérateur était présent même en l'absence de logo, un retour RGAA nous a demandé de le supprimer, j'ai donc hissé le v-if au niveau du lien afin de conserver le même fonctionnement sans que l'accessibilité du composant n'en pâtisse.