### PR TITLE
fix(docs): correction référence DsfrTabs dans useTabs

### DIFF
--- a/src/composables/useTabs.stories.mdx
+++ b/src/composables/useTabs.stories.mdx
@@ -4,7 +4,7 @@ import { Meta } from '@storybook/blocks';
 
 # `useTabs`
 
-Ce composable permet de gérer simplement les props de [DsfrTabs](/?path=/docs/composants-dsfrtabs--docs) et de ses enfants pour gérer l’affichage du contenu de l’onglet (grâce à la prop `selected` de `DsfrTabContent`) et le sens de l’animation (grâce à la prop `asc` sur `DsfrTabContent`).
+Ce composable permet de gérer simplement les props de [DsfrTabs](/docs/composants-dsfrtabs--docs) et de ses enfants pour gérer l’affichage du contenu de l’onglet (grâce à la prop `selected` de `DsfrTabContent`) et le sens de l’animation (grâce à la prop `asc` sur `DsfrTabContent`).
 
 ## Utilisation avancée (Script setup)
 


### PR DESCRIPTION
le lien généré n'était pas fonctionnel: https://vue-dsfr.netlify.app/?path=/?path=/docs/composants-dsfrtabs--docs

Lien attendu: https://vue-dsfr.netlify.app/?path=/docs/composants-dsfrtabs--docs