### PR TITLE
docs(vitepress): 📝 Migration de Storybook vers VitePress

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -5,6 +5,65 @@ import { whyframe } from '@whyframe/core'
 import { whyframeVue } from '@whyframe/vue'
 import { hmrFix } from './plugins/hmrFix.js'
 
+const composants = [
+  {
+    text: 'DsfrAccordion',
+    link: '/composants/DsfrAccordion.md',
+  },
+  {
+    text: 'DsfrAlert',
+    link: '/composants/DsfrAlert.md',
+  },
+  {
+    text: 'DsfrBackToTop',
+    link: '/composants/DsfrBackToTop.md',
+  },
+  {
+    text: 'DsfrBadge',
+    link: '/composants/DsfrBadge.md',
+  },
+  {
+    text: 'DsfrBreadcrumb',
+    link: '/composants/DsfrBreadcrumb.md',
+  },
+  {
+    text: 'DsfrButton',
+    link: '/composants/DsfrButton.md',
+  },
+  {
+    text: 'DsfrButtonGroup',
+    link: '/composants/DsfrButtonGroup.md',
+  },
+  {
+    text: 'DsfrCard',
+    link: '/composants/DsfrCard.md',
+  },
+  {
+    text: 'DsfrRange',
+    link: '/composants/DsfrRange.md',
+  },
+  {
+    text: 'DsfrNotice',
+    link: '/composants/DsfrNotice.md',
+  },
+  {
+    text: 'DsfrSegmented',
+    link: '/composants/DsfrSegmented.md',
+  },
+  {
+    text: 'DsfrSegmentedSet',
+    link: '/composants/DsfrSegmentedSet.md',
+  },
+  {
+    text: 'DsfrTag',
+    link: '/composants/DsfrTag.md',
+  },
+  {
+    text: 'DsfrTooltip',
+    link: '/composants/DsfrTooltip.md',
+  },
+]
+
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
   title: "VueDsfr",
@@ -27,12 +86,12 @@ export default defineConfig({
     },
     logo: '/nouveau-logo-marianne-gouvernement.png',
     nav: [
-      { text: 'Home', link: '/' },
+      { text: 'Guide', link: '/pour-commencer' },
       {
         text: 'Références',
         items: [
-          { text: 'Composants', link: '/composants' },
-          { text: 'Nuxt 3', link: '/nuxt/' }
+          { text: 'Tous les composants', link: '/composants' },
+          { text: 'Tous les types', link: '/types' }
         ]
       },
       {
@@ -42,7 +101,12 @@ export default defineConfig({
             text: 'Système de Design Français',
             link: 'https://www.systeme-de-design.gouv.fr/',
             target: '_blank'
-          }
+          },
+          {
+            text: 'Storybook de VueDsfr',
+            link: 'https://vue-ds.fr/',
+            target: '_blank'
+          },
         ]
       }
     ],
@@ -72,102 +136,46 @@ export default defineConfig({
         },
       }
     },
-    sidebar: [
-      {
-        text: 'Pour commencer',
-        collapsed: false,
-        items: [
-          {
-            text: 'Commencer',
-            link: '/pour-commencer',
-          },
-          {
-            text: 'L’écosystème',
-            link: '/ecosysteme',
-          },
-          {
-            text: 'Les icônes',
-            link: '/icones',
-          },
-          {
-            text: 'Guide du développeur',
-            link: '/guide-developpeur',
-          },
-        ]
-      },
-      {
-        text: 'Tous les types',
-        link: '/types',
-        items: []
-      },
-      {
-        text: 'Tous les composants',
-        link: '/composants',
-        collapsed: false,
-        items: [
-          {
-            text: 'DsfrAccordion',
-            link: '/composants/DsfrAccordion.md',
-          },
-          {
-            text: 'DsfrAlert',
-            link: '/composants/DsfrAlert.md',
-          },
-          {
-            text: 'DsfrBackToTop',
-            link: '/composants/DsfrBackToTop.md',
-          },
-          {
-            text: 'DsfrBadge',
-            link: '/composants/DsfrBadge.md',
-          },
-          {
-            text: 'DsfrBreadcrumb',
-            link: '/composants/DsfrBreadcrumb.md',
-          },
-          {
-            text: 'DsfrButton',
-            link: '/composants/DsfrButton.md',
-          },
-          {
-            text: 'DsfrButtonGroup',
-            link: '/composants/DsfrButtonGroup.md',
-          },
-          {
-            text: 'DsfrCard',
-            link: '/composants/DsfrCard.md',
-          },
-          {
-            text: 'DsfrRange',
-            link: '/composants/DsfrRange.md',
-          },
-          {
-            text: 'DsfrNotice',
-            link: '/composants/DsfrNotice.md',
-          },
-          {
-            text: 'DsfrSegmented',
-            link: '/composants/DsfrSegmented.md',
-          },
-          {
-            text: 'DsfrSegmentedSet',
-            link: '/composants/DsfrSegmentedSet.md',
-          },
-          {
-            text: 'DsfrTag',
-            link: '/composants/DsfrTag.md',
-          },
-          {
-            text: 'DsfrTooltip',
-            link: '/composants/DsfrTooltip.md',
-          },
-        ]
-      },
-      {
-        text: 'Recettes nuxt',
-        link: '/nuxt/',
-      },
-    ],
+    sidebar: {
+      '/composants': composants,
+      '/': [
+        {
+          text: 'Introduction',
+          items: [
+            {
+              text: 'Commencer',
+              link: '/pour-commencer',
+            },
+            {
+              text: 'L’écosystème',
+              link: '/ecosysteme',
+            },
+            {
+              text: 'Les icônes',
+              link: '/icones',
+            },
+            {
+              text: 'Guide du développeur',
+              link: '/guide-developpeur',
+            },
+          ]
+        },
+        {
+          text: 'Tous les types',
+          link: '/types',
+          items: []
+        },
+        {
+          text: 'Tous les composants',
+          link: '/composants',
+          items: []
+        },
+        {
+          text: 'Recettes nuxt',
+          link: '/nuxt/',
+        },
+      ],
+    },
 
     socialLinks: [
       { icon: 'github', link: 'https://github.com/dnum-mi/vue-dsfr' },

--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -21,6 +21,18 @@ export default defineConfig({
   },
 
   themeConfig: {
+    docFooter: {
+      next: 'Page suivante',
+      prev: 'Page précédente',
+    },
+    logo: '/nouveau-logo-marianne-gouvernement.png',
+    nav: [
+      { text: 'Home', link: '/' },
+    ],
+    outline:{
+      level: [2, 3],
+      label: 'Sur cette page :',
+    },
     search: {
       provider: 'local',
       options: {
@@ -43,16 +55,6 @@ export default defineConfig({
         },
       }
     },
-    outline:{
-      level: [2, 3],
-      label: 'Sur cette page :',
-    },
-    logo: '/nouveau-logo-marianne-gouvernement.png',
-    // https://vitepress.dev/reference/default-theme-config
-    nav: [
-      { text: 'Home', link: '/' },
-    ],
-
     sidebar: [
       {
         text: 'Pour commencer',

--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -28,6 +28,23 @@ export default defineConfig({
     logo: '/nouveau-logo-marianne-gouvernement.png',
     nav: [
       { text: 'Home', link: '/' },
+      {
+        text: 'Références',
+        items: [
+          { text: 'Composants', link: '/composants' },
+          { text: 'Nuxt 3', link: '/nuxt/' }
+        ]
+      },
+      {
+        text: 'Liens',
+        items: [
+          {
+            text: 'Système de Design Français',
+            link: 'https://www.systeme-de-design.gouv.fr/',
+            target: '_blank'
+          }
+        ]
+      }
     ],
     outline:{
       level: [2, 3],
@@ -153,7 +170,8 @@ export default defineConfig({
     ],
 
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/dnum-mi/vue-dsfr' }
+      { icon: 'github', link: 'https://github.com/dnum-mi/vue-dsfr' },
+      { icon: 'discord', link: 'https://discord.gg/jbBJ9769ZZ' }
     ]
   },
 

--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -202,3 +202,7 @@
 .flex-end {
   justify-content: flex-end;
 }
+
+.flex-wrap {
+  flex-wrap: wrap;
+}

--- a/docs/docs-demo/DemoIconesDansComposants.vue
+++ b/docs/docs-demo/DemoIconesDansComposants.vue
@@ -1,14 +1,19 @@
 <template>
-  <div class="fr-p-2w  flex gap-4">
+  <div class="fr-p-2w  flex gap-4  flex-wrap">
+    <DsfrButton icon="fr-icon-close-line">
+      Texte avec icône Dsfr
+    </DsfrButton>
+
     <DsfrButton icon="ri-close-line">
-      Texte avec icône
+      Texte avec icône OhVueIcon
     </DsfrButton>
 
     <DsfrButton
       :icon="{name: 'ri-close-line', fill: 'purple'}"
       secondary
     >
-      Texte avec icône violette
+      Texte avec icône
+      OhVueIcon violette
     </DsfrButton>
   </div>
 </template>

--- a/docs/ecosysteme.md
+++ b/docs/ecosysteme.md
@@ -26,10 +26,10 @@ Cette documentation faite avec [Vitepress](https://vitepress.dev/) et disponible
 
 ## L’assistant create-vue-dsfr
 
-Cet assistant disponible aussi sur <VIconLink href="https://www.npmjs.com/package/create-vue-dsfr" icon="si-npm">NPM</VIconLink>
-et son le code source disponible sur <VIconLink href="https://github.com/laruiss/create-vue-dsfr" icon="si-github">GitHub</VIconLink>.
+Cet assistant est aussi disponible sur <VIconLink href="https://www.npmjs.com/package/create-vue-dsfr" icon="si-npm">NPM</VIconLink>
+et son code source disponible sur <VIconLink href="https://github.com/laruiss/create-vue-dsfr" icon="si-github">GitHub</VIconLink>.
 
-Il permet d’échaffauder très rapidement une application avec Vue3 et Vite ou Nuxt 3, VueDsfr, Cypress (pour Vite seulement), Vitest (pour Vite seulement), TypeScript et ESLint déjà paramétrés.
+Il permet d’échaffauder très rapidement une application avec Vue3 et Vite ou Nuxt 3, VueDsfr, TypeScript et ESLint déjà paramétrés, et optionnellement Cypress et Vitest.
 
 Voir la page ["Commencer"](./pour-commencer.md#utiliser-create-vue-dsfr-fortement-recommande) pour son utilisation.
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,0 +1,105 @@
+# Introduction
+
+VueDsfr est un **portage** du **[Système de design français][dsfr]**
+en **[Vue 3][vue3]** sous forme de **bibliothèque de composants**.
+
+Le code est [ouvert et disponible sur GitHub][github-vue-dsfr].
+
+## Pourquoi VueDsfr ?
+
+Le Bureau des ressources et réalisations (BRR) a choisi sa stack technique pour le front, et elle inclut
+Vue 3. Le Système de design français (DSFR) est développé en JavaScript natif et en SCSS (SASS).
+
+Le BRR a donc besoin d'un portage en Vue 3 de ce DSFR pour ses futurs projets qui devront le respecter.
+
+## VueDsfr en quelques mots
+
+Ce projet de bibliothèque de composants :
+
+- reproduit le plus fidèlement possible les composants du [DSFR][dsfr] ;
+- est fait avec [Vue 3][vue3] ;
+- est utilisable facilement en tant que plugin Vue 3 ou Nuxt 3 ;
+- exporte les types (TypeScript) du plugin, des composants et des composables ;
+- est utilisable facilement dans un projet [npm][vue-dsfr-npm] ;
+- met à disposition deux parties dans la documentation :
+  - une pour [aider au développement](/?path=/story/docs-3-guide-du-développeur--page) ;
+  - une autre pour l'[utilisation](/?path=/story/docs-2-guide-d-utilisation--page) ;
+- publie un [site complet][vue-dsfr] disponible pour tous avec les composants et leurs variants testables dans celui-ci dans un storybook ;
+- a une couverture de test optimale ;
+- met à disposition les composants individuellement sans avoir à importer toute la bibliothèque (pour les petits projets).
+
+## Les choix techniques retenus
+
+### Cadriciels de travail
+
+La bibliothèque est faite avec [Vue 3][vue3] et [Vue-router 4][vue-router].
+
+La bibliothèque est mise en paquet grâce à [Vite][vite] en [mode bibliothèque][vite-library-mode].
+
+Le CSS est écrit avec [PostCSS]{postcss} et notamment le plugin [postcss-preset-env][postcss-preset-env] (mais très peu de CSS est propre à la bibliothèque).
+
+Le JavaScript est "linté" avec [ESLint][eslint] et configuré selon [StandardJS][standard-js].
+
+::: info Configuration spécifique
+Ci-dessous les modifications de la configuration de StandardJS :
+
+- les virgules doivent être ajoutées pour tout ce qui est en multiligne (cf. [`comma-dangle`][eslint-comma-dangle]).\
+`"comma-dangle": ["error", "always-multiline"]`
+:::
+
+### Environnements
+
+Le serveur de développement est celui de [Storybook][storybook] et le site pour tester les composants est le storybook lui-même.
+
+Storybook est configuré pour utiliser PostCSS.
+
+### Tests
+
+Les tests sont faits avec [Vitest][vitest] et [Vue Testing Library][vue-testing-library], et des tests d’accessibilité sont faits avec [Cypress][cypress] grâce aux [tests de composants][cypress-component-testing].
+
+### Ressources
+
+Les icônes sont toujours celles de [RemixIcon][remixicon], grâce au DSFR et parfois grâce à [Oh, Vue Icons!][oh-vue-icons] (qui permet d’ajouter d’[autres icônes](/?path=/story/fondamentaux-4-1-icônes-personnalisées--page)).
+
+## Les acteurs du projet
+
+- **Clément Debroize** ;
+- **Pierre-Louis Egaud** ;
+- **Stanislas Ormières** *(Lead dev, architecte, devops, mainteneur principal)*.
+
+Le projet a pu bénéficier des retours et de contributions de :
+
+- [Gildéric Deruette][github-user-gideruette] ;
+- [Sophie Aitis][github-user-sophieaitis] ;
+- et [Ambroise Maupate][github-user-ambroisemaupate].
+
+Merci à vous !
+
+
+<!-- Variables -->
+
+[github-user-ambroisemaupate]: https://github.com/ambroisemaupate
+[github-user-gideruette]: https://github.com/gideruette
+[github-user-sophieaitis]: https://github.com/sophieaitis
+[github-vue-dsfr]: https://github.com/dnum-mi/vue-dsfr/
+
+[dsfr]: https://www.systeme-de-design.gouv.fr/
+[vue-dsfr]: https://vue-dsfr.netlify.app/
+[vue-dsfr-npm]: https://www.npmjs.com/package/@gouvminint/vue-dsfr/
+
+[cypress]: https://www.cypress.io/
+[cypress-component-testing]: https://docs.cypress.io/guides/component-testing/introduction
+[eslint]: https://eslint.org/
+[eslint-comma-dangle]: https://eslint.org/docs/rules/comma-dangle#options
+[oh-vue-icons]: https://github.com/Renovamen/oh-vue-icons/
+[postcss]: https://postcss.org/
+[postcss-preset-env]: https://preset-env.cssdb.org/
+[remixicon]: https://remixicon.com/
+[standard-js]: https://standardjs.org/
+[storybook]: https://storybook.js.org/
+[vite]: https://vitejs.dev/
+[vite-library-mode]: https://vitejs.dev/guide/build.html#library-mode
+[vitest]: https://vitest.dev/
+[vue3]: https://v3.vuejs.org/
+[vue-router]: https://router.vuejs.org/
+[vue-testing-library]: https://testing-library.com/docs/vue-testing-library/intro/

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -55,7 +55,7 @@ Storybook est configuré pour utiliser PostCSS.
 
 ### Tests
 
-Les tests sont faits avec [Vitest][vitest] et [Vue Testing Library][vue-testing-library], et des tests d’accessibilité sont faits avec [Cypress][cypress] grâce aux [tests de composants][cypress-component-testing].
+Les tests sont faits avec [Vitest][vitest] et [Vue Testing Library][vue-testing-library], et des tests d’accessibilité sont faits avec [Cypress][cypress] grâce aux [tests de composants][cypress-component-testing], ainsi qu’avec Storybook pour certains composants (notamment pour tous les tests de la touche tabulation, comme la modale et les onglets).
 
 ### Ressources
 
@@ -71,14 +71,18 @@ Le projet a pu bénéficier des retours et de contributions de :
 
 - [Gildéric Deruette][github-user-gideruette] ;
 - [Sophie Aitis][github-user-sophieaitis] ;
-- et [Ambroise Maupate][github-user-ambroisemaupate].
+- [Ambroise Maupate][github-user-ambroisemaupate] ;
+- [Alexandre Cailliaud][github-user-cailliaud] ;
+- et [Adrien Martinez][github-user-adrylen].
 
 Merci à vous !
 
 
 <!-- Variables -->
 
+[github-user-adrylen]: https://github.com/adrylen
 [github-user-ambroisemaupate]: https://github.com/ambroisemaupate
+[github-user-cailliaud]: https://github.com/cailliaud
 [github-user-gideruette]: https://github.com/gideruette
 [github-user-sophieaitis]: https://github.com/sophieaitis
 [github-vue-dsfr]: https://github.com/dnum-mi/vue-dsfr/

--- a/docs/icones.md
+++ b/docs/icones.md
@@ -26,11 +26,12 @@ Plusieurs composants (`DsfrButton`, `DsfrBadge`, `DsfrCallout`...) ont la prop `
 
 Attention, cette icône n’est pas forcément une icône officielle du DSFR. En effet, VueDsfr utilise la bibliothèque [`oh-vue-icons`](https://oh-vue-icons.netlify.app/). Cette prop `icon` est donc :
 
+- soit une `string` qui doit être un nom de classe valide pour une icône du DSFR (qui commence par `'fr-icon-'`) ;
 - soit une `string` qui doit être un nom d’icône valide pour OhVueIcon ;
 - soit la prop complète attendue par le composant `OhVueIcon` de la bibliothèque [`oh-vue-icons`](https://oh-vue-icons.netlify.app/).
 
 ::: warning
-Dans les deux cas il faut que cette icône ait été ajoutée (cf. plus loin)
+Dans le cas où c’est une icône OhVueIcon qui est utilisée, il faut que cette icône ait été ajoutée (cf. plus loin)
 :::
 
 ::: code-group

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,9 +3,9 @@
 layout: home
 
 hero:
-  name: "VueDsfr"
-  text: "Portage en Vue du DSFR"
-  tagline: Une documentation plus "user-friendly" que le storybook 😜
+  name: VueDsfr
+  text: Portage en Vue du DSFR
+  tagline: Une bibliothèque de composants du Système de design français en Vue 3.
   actions:
     - theme: brand
       text: Pour commencer
@@ -19,12 +19,12 @@ hero:
 
 features:
   - title: Facile d’utilisation
-    details: VueDsfr est distribuée sous forme de plugin Vue3
+    details: VueDsfr est distribuée sous forme de plugin Vue3.
   - title: A11y
-    details: Une bibliothèque prête pour viser une très bonne note RGAA
+    details: Une bibliothèque prête pour viser une très bonne note RGAA.
   - title: Personnalisable
-    details: Avec ses nombreuses utilisations de slot
+    details: Avec ses nombreuses utilisations de slot.
   - title: Prête pour TypeScript
-    details: Écrite en TS, tous les composants et leurs props sont typés
+    details: Écrite en TS, tous les composants et leurs propriétés sont typés.
 ---
 


### PR DESCRIPTION
**Pour information**, il s'agit d'une première étape de la migration des éléments de StoryBook vers VitePress.

Deux options s'ouvrent à cette migration :
- Cette branche fait office référence avant une intégration finale ;
- Cette branche sera fusionnée en `develop` et d'autres apporteront des modifications supplémentaires par la suite.

**Vérifications à effectuer**

- Les liens **externes** de navigation et de la [page d'introduction](http://localhost:5173/guide/) doivent être fonctionnels ;
- [TODO] Les liens **internes** de navigation et de la [page d'introduction](http://localhost:5173/guide/) doivent rediriger vers une page vitepress ;
- Le lien Discord est fonctionnel.