### PR TITLE
feat: support external links in footer *mandatoryLinks

### DIFF
--- a/src/components/DsfrFooter/DsfrFooter.spec.ts
+++ b/src/components/DsfrFooter/DsfrFooter.spec.ts
@@ -90,7 +90,10 @@ describe('DsfrFooter', () => {
       },
       props: {
         a11yCompliance: 'totalement conforme',
-        afterMandatoryLinks: [{ label: 'After', to: testIdAfterLink }],
+        afterMandatoryLinks: [
+          { label: 'After', to: testIdAfterLink },
+          { label: 'After ext', to: 'https://example.com' },
+        ],
         beforeMandatoryLinks: [{ label: 'Before', to: testIdBeforeLink }],
         partners,
       },
@@ -100,10 +103,13 @@ describe('DsfrFooter', () => {
 
     const ecosystemLinksLis = container.querySelectorAll('.fr-footer__content-list .fr-footer__content-link')
     const partnerLinks = container.querySelectorAll('.fr-footer__partners-link')
+    const bottomLinks = container.querySelectorAll('.fr-footer__bottom-link')
+    const extLinks = [...bottomLinks].filter((link) => link.getAttribute('href')?.startsWith('https'))
 
     // Then
     expect(ecosystemLinksLis).toHaveLength(4)
     expect(partnerLinks).toHaveLength(3)
+    expect(extLinks).toHaveLength(1)
     expect(getByTestId(testIdMentionsLegales)).toHaveClass('fr-footer__bottom-link')
     expect(getByTestId(testIdBeforeLink)).toHaveClass('fr-footer__bottom-link')
     expect(getByTestId(testIdAfterLink)).toHaveClass('fr-footer__bottom-link')

--- a/src/components/DsfrFooter/DsfrFooter.types.ts
+++ b/src/components/DsfrFooter/DsfrFooter.types.ts
@@ -33,9 +33,9 @@ export type DsfrFooterProps = {
   cookiesLink?: string
   logoText?: string | string[]
   descText?: string
-  beforeMandatoryLinks?: {label: string, to: string | RouteLocationRaw | undefined}[]
-  afterMandatoryLinks?: {label: string, to: string | RouteLocationRaw | undefined}[]
-  mandatoryLinks?: {label: string, to: string | RouteLocationRaw | undefined}[]
+  beforeMandatoryLinks?: {label: string, to: RouteLocationRaw | undefined}[]
+  afterMandatoryLinks?: {label: string, to: RouteLocationRaw | undefined}[]
+  mandatoryLinks?: {label: string, to: RouteLocationRaw | undefined}[]
   ecosystemLinks?: {label: string, href: string}[]
   operatorLinkText?: string
   operatorTo?: RouteLocationRaw | undefined

--- a/src/components/DsfrFooter/DsfrFooter.types.ts
+++ b/src/components/DsfrFooter/DsfrFooter.types.ts
@@ -33,9 +33,9 @@ export type DsfrFooterProps = {
   cookiesLink?: string
   logoText?: string | string[]
   descText?: string
-  beforeMandatoryLinks?: {label: string, to: RouteLocationRaw | undefined}[]
-  afterMandatoryLinks?: {label: string, to: RouteLocationRaw | undefined}[]
-  mandatoryLinks?: {label: string, to: RouteLocationRaw | undefined}[]
+  beforeMandatoryLinks?: {label: string, to: string | RouteLocationRaw | undefined}[]
+  afterMandatoryLinks?: {label: string, to: string | RouteLocationRaw | undefined}[]
+  mandatoryLinks?: {label: string, to: string | RouteLocationRaw | undefined}[]
   ecosystemLinks?: {label: string, href: string}[]
   operatorLinkText?: string
   operatorTo?: RouteLocationRaw | undefined

--- a/src/components/DsfrFooter/DsfrFooter.vue
+++ b/src/components/DsfrFooter/DsfrFooter.vue
@@ -187,7 +187,14 @@ const aLicenceHref = computed(() => {
             :key="index"
             class="fr-footer__bottom-item"
           >
+            <a
+              v-if="typeof link.to === 'string' && link.to.startsWith('http')"
+              class="fr-footer__bottom-link"
+              :href="link.to"
+              :data-testid="link.to"
+            >{{ link.label }}</a>
             <RouterLink
+              v-else
               class="fr-footer__bottom-link"
               :to="link.to ?? '#'"
               :data-testid="link.to"


### PR DESCRIPTION
Il est [parfois nécessaire d'inclure des liens externes](https://github.com/ecolabdata/ecospheres-front/pull/247) dans les liens obligatoires du footer. 

Cette proposition ajoute le support de ces liens externes, de manière similaire à ce qui est fait dans `DsfrFooterLinkList`, pour les props `beforeMandatoryLinks`, `mandatoryLinks` and `afterMandatoryLinks`.