### PR TITLE
feat: Introduction de la fonctionnalité améliorée de clé de ligne dans le tableau de données

### DIFF
--- a/src/components/DsfrTable/DsfrTable.types.ts
+++ b/src/components/DsfrTable/DsfrTable.types.ts
@@ -24,7 +24,7 @@ export type DsfrTableProps = {
   title: string
   headers?: DsfrTableHeadersProps
   rows?:(DsfrTableRowProps | string[])[]
-  rowKey?: (row: any) => number | string
+  rowKey?: (row: any) => number | string | symbol 
   noCaption?: boolean
   pagination?: boolean
   currentPage?: number

--- a/src/components/DsfrTable/DsfrTable.types.ts
+++ b/src/components/DsfrTable/DsfrTable.types.ts
@@ -23,8 +23,9 @@ export type DsfrTableCellProps = {
 export type DsfrTableProps = {
   title: string
   headers?: DsfrTableHeadersProps
-  rows?:(DsfrTableRowProps | string[])[]
-  rowKey?: string
+  rows?: (DsfrTableRowProps | string[])[]
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  rowKey?: ((row: (string | Record<string, any>)[] | undefined) => string | number | symbol | undefined) | string
   noCaption?: boolean
   pagination?: boolean
   currentPage?: number

--- a/src/components/DsfrTable/DsfrTable.types.ts
+++ b/src/components/DsfrTable/DsfrTable.types.ts
@@ -24,6 +24,7 @@ export type DsfrTableProps = {
   title: string
   headers?: DsfrTableHeadersProps
   rows?:(DsfrTableRowProps | string[])[]
+  rowKey?: (row: any) => number | string
   noCaption?: boolean
   pagination?: boolean
   currentPage?: number

--- a/src/components/DsfrTable/DsfrTable.types.ts
+++ b/src/components/DsfrTable/DsfrTable.types.ts
@@ -24,7 +24,7 @@ export type DsfrTableProps = {
   title: string
   headers?: DsfrTableHeadersProps
   rows?:(DsfrTableRowProps | string[])[]
-  rowKey?: (row: any) => number | string | symbol 
+  rowKey?: string
   noCaption?: boolean
   pagination?: boolean
   currentPage?: number

--- a/src/components/DsfrTable/DsfrTable.vue
+++ b/src/components/DsfrTable/DsfrTable.vue
@@ -88,7 +88,7 @@ const goLastPage = () => {
         <template v-if="rows && rows.length">
           <DsfrTableRow
             v-for="(row, i) of truncatedResults"
-            :key="i"
+            :key="rowKey ? rowKey(getRowData(row)) : i"
             :row-data="getRowData(row)"
             :row-attrs="'rowAttrs' in row ? row.rowAttrs : {}"
           />

--- a/src/components/DsfrTable/DsfrTable.vue
+++ b/src/components/DsfrTable/DsfrTable.vue
@@ -16,22 +16,30 @@ const props = withDefaults(defineProps<DsfrTableProps>(), {
 })
 
 // Permet aux utilisateurs d'utiliser une fonction afin de charger des résultats au changement de page
-const emit = defineEmits<{(event: 'update:currentPage'): void}>()
+const emit = defineEmits<{(event: 'update:currentPage'): void }>()
 
-const getRowData = (row: (DsfrTableRowProps | string[])) => {
+const getRowData = (row: DsfrTableRowProps | string[]) => {
   return Array.isArray(row) ? row : row.rowData
 }
 
 const currentPage = ref(props.currentPage)
 const optionSelected = ref(props.resultsDisplayed)
-const pageCount = ref(props.rows.length > optionSelected.value ? Math.ceil(props.rows.length / optionSelected.value) : 1)
+const pageCount = ref(
+  props.rows.length > optionSelected.value
+    ? Math.ceil(props.rows.length / optionSelected.value)
+    : 1,
+)
 const paginationOptions = [5, 10, 25, 50, 100]
 const returnLowestLimit = () => currentPage.value * optionSelected.value - optionSelected.value
 const returnHighestLimit = () => currentPage.value * optionSelected.value
 
-watch(() => optionSelected.value, (newVal) => {
-  pageCount.value = props.rows.length > optionSelected.value ? Math.ceil(props.rows.length / newVal) : 1
-})
+watch(
+  () => optionSelected.value,
+  (newVal) => {
+    pageCount.value =
+      props.rows.length > optionSelected.value ? Math.ceil(props.rows.length / newVal) : 1
+  },
+)
 
 const truncatedResults = computed(() => {
   if (props.pagination) {
@@ -68,11 +76,11 @@ const goLastPage = () => {
     class="fr-table"
     :class="{ 'fr-table--no-caption': noCaption }"
   >
-    <table
-      class="simple-table"
-    >
+    <table class="simple-table">
       <caption class="caption">
-        {{ title }}
+        {{
+          title
+        }}
       </caption>
       <thead>
         <!-- @slot Slot "header" pour les en-têtes du tableau. Sera dans `<thead>` -->
@@ -89,7 +97,13 @@ const goLastPage = () => {
         <template v-if="rows && rows.length">
           <DsfrTableRow
             v-for="(row, i) of truncatedResults"
-            :key="(rowKey && getRowData(row)) ? getRowData(row)![headers.indexOf(rowKey)].toString() : i"
+            :key="
+              rowKey && getRowData(row)
+                ? typeof rowKey === 'string'
+                  ? getRowData(row)![headers.indexOf(rowKey)].toString()
+                  : rowKey(getRowData(row))
+                : i
+            "
             :row-data="getRowData(row)"
             :row-attrs="'rowAttrs' in row ? row.rowAttrs : {}"
           />
@@ -112,10 +126,10 @@ const goLastPage = () => {
                   </option>
                 </select>
               </div>
-              <div class="flex  ml-1">
+              <div class="flex ml-1">
                 <span class="self-center">Page {{ currentPage }} sur {{ pageCount }}</span>
               </div>
-              <div class="flex   ml-1">
+              <div class="flex ml-1">
                 <button
                   class="fr-icon-arrow-left-s-first-line"
                   @click="goFirstPage()"
@@ -142,19 +156,19 @@ const goLastPage = () => {
 </template>
 
 <style scoped>
-  .flex {
-    display: flex;
-  }
+.flex {
+  display: flex;
+}
 
-  .justify-right {
-    justify-content: right;
-  }
+.justify-right {
+  justify-content: right;
+}
 
-  .ml-1 {
-    margin-left: 1rem;
-  }
+.ml-1 {
+  margin-left: 1rem;
+}
 
-  .self-center {
-    align-self: center;
-  }
+.self-center {
+  align-self: center;
+}
 </style>

--- a/src/components/DsfrTable/DsfrTable.vue
+++ b/src/components/DsfrTable/DsfrTable.vue
@@ -92,7 +92,7 @@ const goLastPage = () => {
         </slot>
       </thead>
       <tbody>
-        <!-- @slot Slot par défaut pour le corps du tableau. Sera dans `<tbody>` -->
+        <!-- @slot Slot par défaut pour le corps du tableau. Sera dans `<tbody>`  -->
         <slot />
         <template v-if="rows && rows.length">
           <DsfrTableRow

--- a/src/components/DsfrTable/DsfrTable.vue
+++ b/src/components/DsfrTable/DsfrTable.vue
@@ -89,7 +89,7 @@ const goLastPage = () => {
         <template v-if="rows && rows.length">
           <DsfrTableRow
             v-for="(row, i) of truncatedResults"
-            :key="rowKey ? rowKey(getRowData(row)) : i"
+            :key="(rowKey && getRowData(row)) ? getRowData(row)![headers.indexOf(rowKey)].toString() : i"
             :row-data="getRowData(row)"
             :row-attrs="'rowAttrs' in row ? row.rowAttrs : {}"
           />

--- a/src/components/DsfrTable/DsfrTable.vue
+++ b/src/components/DsfrTable/DsfrTable.vue
@@ -92,7 +92,7 @@ const goLastPage = () => {
         </slot>
       </thead>
       <tbody>
-        <!-- @slot Slot par défaut pour le corps du tableau. Sera dans `<tbody>`  -->
+        <!-- @slot Slot par défaut pour le corps du tableau. Sera dans `<tbody>` -->
         <slot />
         <template v-if="rows && rows.length">
           <DsfrTableRow

--- a/src/components/DsfrTable/DsfrTable.vue
+++ b/src/components/DsfrTable/DsfrTable.vue
@@ -10,6 +10,7 @@ export type { DsfrTableProps }
 const props = withDefaults(defineProps<DsfrTableProps>(), {
   headers: () => [],
   rows: () => [],
+  rowKey: undefined,
   currentPage: 1,
   resultsDisplayed: 10,
 })


### PR DESCRIPTION
feat: Introduction de la fonctionnalité améliorée de clé de ligne dans le tableau de données

Cette demande d'extraction traite d'une amélioration cruciale de la fonctionnalité du tableau de données en introduisant la possibilité de définir une clé de ligne personnalisée. La mise en œuvre actuelle, où table-row dépend de l'index de la boucle, s'est avérée inexacte lors de la mise à jour du tableau avec de nouvelles données.

- Ajout de l'attribut `row-key` au composant `<DsfrTable>`.
- Les utilisateurs peuvent désormais spécifier la clé de ligne souhaitée, améliorant la capacité du tableau à se mettre à jour ou à se réafficher correctement.

```html
<DsfrTable
    :title="title"
    :headers="['applicationid', 'longname', 'comments', 'createdat']"
    row-key="applicationid"
    :rows="rows"
/>
```

```html
<DsfrTable
    :title="title"
    :headers="['applicationid', 'longname', 'comments', 'createdat']"
    row-key=" (rowData) =>renvoyer une clé unique"
    :rows="rows"
/>
```