### PR TITLE
fix: :label: accept array of DsfrTableCellProps in DsfrTableRowsProps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16792,9 +16792,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "dev": true,
       "funding": [
         {
@@ -29925,9 +29925,9 @@
       "dev": true
     },
     "node_modules/vite": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.8.tgz",
-      "integrity": "sha512-jYMALd8aeqR3yS9xlHd0OzQJndS9fH5ylVgWdB+pxTwxLKdO1pgC5Dlb398BUxpfaBxa4M9oT7j1g503Gaj5IQ==",
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.12.tgz",
+      "integrity": "sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.19.3",

--- a/src/components/DsfrTable/DsfrTable.types.ts
+++ b/src/components/DsfrTable/DsfrTable.types.ts
@@ -18,12 +18,17 @@ export type DsfrTableHeadersProps = (string | (DsfrTableHeaderProps & { text?: s
 export type DsfrTableCellProps = {
   field: string | Record<string, unknown>
   cellAttrs?: TdHTMLAttributes
+  component?: string,
+  text?: string,
+  title?: string,
+  class?: string,
+  onClick?: Promise<void>,
 }
 
 export type DsfrTableProps = {
   title: string
   headers?: DsfrTableHeadersProps
-  rows?: (DsfrTableRowProps | string[])[]
+  rows?: (DsfrTableRowProps | string[] | DsfrTableCellProps[])[]
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   rowKey?: ((row: (string | Record<string, any>)[] | undefined) => string | number | symbol | undefined) | string
   noCaption?: boolean

--- a/src/components/DsfrTable/DsfrTable.vue
+++ b/src/components/DsfrTable/DsfrTable.vue
@@ -3,7 +3,7 @@ import { computed, ref, watch } from 'vue'
 import DsfrTableRow, { type DsfrTableRowProps } from './DsfrTableRow.vue'
 import DsfrTableHeaders from './DsfrTableHeaders.vue'
 
-import type { DsfrTableProps } from './DsfrTable.types'
+import type { DsfrTableCellProps, DsfrTableProps } from './DsfrTable.types'
 
 export type { DsfrTableProps }
 
@@ -18,7 +18,7 @@ const props = withDefaults(defineProps<DsfrTableProps>(), {
 // Permet aux utilisateurs d'utiliser une fonction afin de charger des résultats au changement de page
 const emit = defineEmits<{(event: 'update:currentPage'): void }>()
 
-const getRowData = (row: DsfrTableRowProps | string[]) => {
+const getRowData = (row: DsfrTableRowProps | string[] | DsfrTableCellProps[]) => {
   return Array.isArray(row) ? row : row.rowData
 }
 


### PR DESCRIPTION
Je crée une `DsfrTable` en lui passant une props `rows` issue de ma fonction `getRows`, typée comme ci-dessous :

```js
const getRows: (arrArg: ArgType[]) => {
    component: string;
    text: string;
    title: string;
    class: string;
    onClick: () => any;
}[][]
```

TS m'indique une erreur de typage sur la props `rows` : 

```js
Type '{ component: string; text: string; title: string; class: string; onClick: () => any; }[][]' is not assignable to type '(string[] | DsfrTableRowProps)[]'.ts(2322)
DsfrTable.vue.d.ts(23, 5): The expected type comes from property 'rows' which is declared here on type 'Partial<{ currentPage: number; headers: DsfrTableHeadersProps; rows: (string[] | DsfrTableRowProps)[]; rowKey: string | [...] 
```