### PR TITLE
fix(DsfrRadioButtonSet): 🐛 modelValue undefined

### DIFF
--- a/src/components/DsfrRadioButton/DsfrRadioButton.types.ts
+++ b/src/components/DsfrRadioButton/DsfrRadioButton.types.ts
@@ -1,7 +1,7 @@
 export type DsfrRadioButtonProps = {
   id?: string
   name?: string
-  modelValue?: string | number
+  modelValue?: string | number | undefined
   small?: boolean
   inline?: boolean
   value: string | number
@@ -20,6 +20,6 @@ export type DsfrRadioButtonSetProps = {
   errorMessage?: string,
   validMessage?: string,
   legend?: string,
-  modelValue: string | number,
+  modelValue: string | number | undefined,
   options?: DsfrRadioButtonProps[],
 }


### PR DESCRIPTION
Désormais, modelValue peut prendre la valeur undefined dans
la prop modelValue de DsfrRadioButtonSet.