### PR TITLE
docs: 📝 corrections de liens

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -246,7 +246,7 @@ export default defineConfig({
           },
           {
             text: 'Storybook de VueDsfr',
-            link: 'https://vue-ds.fr/',
+            link: 'https://storybook.vue-ds.fr/',
             target: '_blank'
           },
         ],

--- a/demo-app/App.vue
+++ b/demo-app/App.vue
@@ -51,7 +51,7 @@ const quickLinks: DsfrHeaderProps['quickLinks'] = [
   },
   {
     label: 'DSFR',
-    href: 'https://systeme-de-design.gouv.fr/',
+    href: 'https://www.systeme-de-design.gouv.fr/',
   },
 ]
 

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2,7 +2,7 @@
 
 La nouvelle documentation des composants est en cours d’écriture.
 
-Le storybook est toujours disponible [ici](https://vue-ds.fr)
+Le storybook est toujours disponible [ici](https://storybook.vue-ds.fr)
 
 ## Accordéon
 

--- a/docs/guide/ecosysteme.md
+++ b/docs/guide/ecosysteme.md
@@ -19,7 +19,7 @@ et son code source disponible sur <VIconLink href="https://github.com/dnum-mi/vu
 
 Elle permet de créer facilement des applications Vue qui respectent le DSFR.
 
-Le storybook avec tous les composants est disponible sur <https://vue-ds.fr>
+Le storybook avec tous les composants est disponible sur <https://storybook.vue-ds.fr>
 
 Cette documentation faite avec [Vitepress](https://vitepress.dev/) et disponible sur <https://docs.vue-ds.fr> nous a paru plus lisible et accessible qu’un storybook pour un utilisateur de la bibliothèque. Elle est toute récente et encore très incomplète, et son organisation est susceptible de changer (en fonction, notamment, des premiers retours utilisateurs).
 

--- a/src/components/DsfrHeader/DsfrHeader.stories.ts
+++ b/src/components/DsfrHeader/DsfrHeader.stories.ts
@@ -50,7 +50,7 @@ export default {
       description: `Tableau des liens d’accès rapide, chaque objet contiendra les props suivantes :
 - \`label\`: Texte du lien (\`'Notifications'\`, par ex.)
 - \`to\`: Chemin ou objet à passer à \`to\` de \`RouterLink\` (\`'/notification'\` ou \`{ name: 'Notifications' }\` par ex.)
-- \`href\`: URL à passer à \`href\` de la balise \`<a>\` (\`'https://systeme-de-design.gouv.fr\` par ex.) **pour un lien externe uniquement**.
+- \`href\`: URL à passer à \`href\` de la balise \`<a>\` (\`'https://www.systeme-de-design.gouv.fr\` par ex.) **pour un lien externe uniquement**.
 - \`icon\` Nom de l’icône [Remix Icon](https://remixicon.com/) (ou toute autre icône de [oh-vue-icons](https://oh-vue-icons.netlify.app/)) à afficher (\`'ri-phone-line'\` par ex.)
 - \`target\` La target du lien (\`'_self'\`, \`'_blank'\` par ex.)
 - \`iconRight\` Permet de mettre l’icône à droite (si la valeur est \`true\` ou <em>truthy</em> et que \`icon\` est renseigné )

--- a/src/components/DsfrSegmented/DsfrSegmented.md
+++ b/src/components/DsfrSegmented/DsfrSegmented.md
@@ -8,7 +8,7 @@ Le composant « contrôle segmenté » incite l'utilisateur à choisir entre
 
 🏅 La documentation sur les boutons segmentés sur le [DSFR sera ici](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/controle-segmente) (n’existe pas encore à l’heure où cette documentation est écrite, on est dans l’turfu, nous, qu’on vous dit !).
 
-<VIcon name="vi-file-type-storybook" /> La story sur l’alerte sur le storybook de [VueDsfr est ici](https://vue-ds.fr/?path=/docs/composants-dsfrsegmented--docs) (merci [Vincent Lainé](https://github.com/vincentlaine/) !).
+<VIcon name="vi-file-type-storybook" /> La story sur l’alerte sur le storybook de [VueDsfr est ici](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrsegmented--docs) (merci [Vincent Lainé](https://github.com/vincentlaine/) !).
 
 ## 🛠️ Les props
 

--- a/src/stories/docs/01-intro.stories.mdx
+++ b/src/stories/docs/01-intro.stories.mdx
@@ -11,7 +11,7 @@ import MailIcon from './mail-fill.svg'
 
 Si vous recherchez:
 
-- le [storybook](https://stories.vue-ds.fr), le plus à jour est ici : [https://vue-ds.fr](https://vue-ds.fr) ;
+- le [storybook](https://stories.vue-ds.fr), le plus à jour est ici : [https://storybook.vue-ds.fr](https://storybook.vue-ds.fr) ;
 - l’[application de demo](https://demo.vue-ds.fr) avec plusieurs composants utilisés dans une vraie app Vue 3, c’est ici [https://demo.vue-ds.fr](https://demo.vue-ds.fr) ;
 - la [nouvelle documentation](https://vue-ds.fr), c’est ici [https://docs.vue-ds.fr](https://docs.vue-ds.fr) ou plus simplement [https://vue-ds.fr](https://vue-ds.fr) ;
 


### PR DESCRIPTION
Des corrections de liens présents dans la documentation et le site de démo : 
 - ajout de www. devant systeme-de-design.gouv.fr (évite un message de certificat invalide)
 - certains liens vers le storybook pointaient vers le nouveau site de la documentation

Je vois qu'il y a deux adresses pour le storybook : https://storybook.vue-ds.fr et https://stories.vue-ds.fr.  
Je n'ai pas vu s'il y a une différence ou si le contenu est le même, ce n'est peut-être pas utile d'avoir les deux (la 1ère a plus d'occurrences dans les sources du projet).