### PR TITLE
fix(demo-app): 🐛 Met la navigation dans le slot prévu du header

### DIFF
--- a/demo-app/App.vue
+++ b/demo-app/App.vue
@@ -205,13 +205,15 @@ const navItems: DsfrNavigationProps['navItems'] = [
       :quick-links="quickLinks"
       show-search
       placeholder="Rechercher placeholder"
-    />
+    >
+      <template #mainnav>
+        <DsfrNavigation
+          :nav-items="navItems"
+        />
+      </template>
+    </DsfrHeader>
 
     <div class="fr-container">
-      <DsfrNavigation
-        :nav-items="navItems"
-      />
-
       <h1>Demo VueDsfr</h1>
 
       <DsfrBreadcrumb


### PR DESCRIPTION
Bonjour,

Petite proposition de correction sur la démo pour corriger l'affichage de la navigation en responsive (et mettre en avant une bonne utilisation des composants).