### PR TITLE
fix(DsfrCard): 🐛 implémente detailIcon

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -8,6 +8,7 @@ import { hmrFix } from './plugins/hmrFix.js'
 const minimalToc = [
   {
     text: 'Guide',
+    link: '/guide/',
     items: []
   },
   {

--- a/src/components/DsfrButton/DsfrButton.md
+++ b/src/components/DsfrButton/DsfrButton.md
@@ -72,9 +72,15 @@ Un petit bouton avec le texte 'Aller plus loin', du contenu supplémentaire dans
 
 <<< docs-demo/DsfrButtonDemo.vue [Code de la démo]
 
-<<< DsfrButton.vue
+:::
 
+## ⚙️ Code source du composant
+
+::: code-group
+
+<<< DsfrButton.vue
 <<< DsfrButton.types.ts
+
 :::
 
 Et voilà ! Notre DsfrButton est prêt à illuminer votre interface avec style et fonctionnalité. N'oubliez pas d'appuyer sur ces boutons avec panache ! 🚀

--- a/src/components/DsfrCard/DsfrCard.md
+++ b/src/components/DsfrCard/DsfrCard.md
@@ -4,7 +4,7 @@
 
 La carte c'est tout simplement l'indispensable pour agrémenter vos sites et applications d'amuse-bouches esthétiques vers des contenus proposés. Il s'agit d'un composant permettant un aperçu d'une page et un lien vers cette dernière. Elle fait généralement partie d'une liste menant vers des contenus similaires.
 
-La carte existe en trois tailles (LG, MD, SM) et deux formats (horizontal et vertical) déclinés sur deux supports (desktop et mobile), vous trouverez forcément votre bonheur ! Les cartes horizontales sont réservées au desktop (en mobile, une carte horizontale devient verticale).
+La carte existe en trois tailles (LG, MD, SM) et deux formats (horizontal et vertical) déclinés sur deux supports (desktop et mobile), vous trouverez forcément votre bonheur ! Les cartes horizontales sont réservées au desktop (en mobile, une carte horizontale devient verticale).
 
 🏅 La documentation sur la carte sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/carte)
 
@@ -33,22 +33,24 @@ Autres props :
 
 ## 🛠️ Les props
 
-|  nom                   |   type      |  défaut         | obligatoire        |
-| ---------------------- | ---------   | --------------- | ------------------ |
-| `altImg`               | *`string`*  | `''`            |                    |
-| `buttons`              | *`object`*  | `[]`            |                    |
-| `detail`               | *`string`*  | `''`            |                    |
-| `endDetail`            | *`string`*  | `''`            |                    |
-| `description`          | *`string`*  |                 | ✅                 |
-| `download`             | *`boolean`* | `false`         |                    |
-| `horizontal`           | *`boolean`* | `false`         |                    |
-| `imgSrc`               | *`string`*  | `''`            |                    |
-| `link`                 | *`string`*  | `''`            |                    |
-| `linksGroup`           | *`object`*  | `[]`            |                    |
-| `size`                 | *`string`*  | `'md'`          |                    |
-| `imgRatio`             | *`string`*  | `'md'`          |                    |
-| `title`                | *`string`*  |                 | ✅                 |
-| `titleTag`             | [*`TitleTag`*](/docs/types.md#title-tag "'h1' \| 'h2' \| 'h3' \| 'h4' \| 'h5' \| 'h6'") | `'h3'`          |          |
+|  Nom                   |   Type      |  Défaut         | Obligatoire        | Description |
+| ---------------------- | ---------   | --------------- | ------------------ | ---- |
+| `altImg`               | *`string`*  | `''`            |                    | Contenu de l’attribut `alt` de l’image de la carte |
+| `buttons`              | [*`DsfrButtonProps[]`*](/types#dsfrbutton-et-dsfrbuttongroup)  | `[]`            |                    | Tableau de props à donner à DsfrButton |
+| `detail`               | *`string`*  | `''`            |                    | Texte à mettre dans la première zone de détail |
+| `detailIcon`           | *`string`*  | `''`            |                    | Icône à mettre dans la première zone de détail ([nom d’une icône `oh-vue-icon` ou `DSFR`](/guide/icones)) |
+| `endDetail`            | *`string`*  | `''`            |                    | Texte à mettre dans la deuxième zone de détail |
+| `endDetailIcon         | *`string`*  | `''`            |                    | Icône à mettre dans la deuxième zone de détail ([nom d’une icône `oh-vue-icon` ou `DSFR`](/guide/icones)) |
+| `description`          | *`string`*  |                 | ✅                 | Description de la carte |
+| `download`             | *`boolean`* | `false`         |                    | Est-ce que cette carte permet de télécharger un fichier ? |
+| `horizontal`           | *`boolean`* | `false`         |                    | Est-ce que la carte doit être affiché avec l’image et le texte au même niveau ? |
+| `imgSrc`               | *`string`*  | `''`            |                    | URL vers l’image |
+| `link`                 | *`string`*  | `''`            |                    | Lien vers lequel la carte pointe |
+| `linksGroup`           | *`({ label: string, to?: RouteLocationRaw, link?: string, href?: string })[]`*  | `[]`            |                    | liste de liens : objet contenant `to` ou `href` pour le lien et `label` avec le texte du lien |
+| `size`                 | *`'md' | 'medium' | 'large' | 'lg' | 'sm' | 'small' | undefined`*  | `'md'`          |                    | Taille de la carte |
+| `imgRatio`             | *`'md' | 'medium' | 'large' | 'lg' | 'sm' | 'small' | undefined`*  | `'md'`          |                    |
+| `title`                | *`string`*  |                 | ✅                 | Titre de la carte |
+| `titleTag`             | [*`TitleTag`*](/docs/types.md#title-tag "'h1' \| 'h2' \| 'h3' \| 'h4' \| 'h5' \| 'h6'") | `'h3'`          |          | Balise du titre de la carte |
 
 ## 🧩 Les slots
 
@@ -81,6 +83,15 @@ cf. DSFR : [Composant - Carte](https://www.systeme-de-design.gouv.fr/elements-d
 </Story>
 
 <<< docs-demo/DsfrCardDemoActions.vue [Code de la démo]
+
+:::
+
+## ⚙️ Code source du composant
+
+::: code-group
+
+<<< DsfrCard.vue
+<<< DsfrCard.types.ts
 
 :::
 

--- a/src/components/DsfrCard/DsfrCard.types.ts
+++ b/src/components/DsfrCard/DsfrCard.types.ts
@@ -20,7 +20,13 @@ export type DsfrCardProps = {
   altImg?: string
   titleTag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
   buttons?: DsfrButtonProps[]
-  linksGroup?:({ label: string, to?: RouteLocationRaw, link?: string, href?: string })[]
+  linksGroup?: {
+    label: string
+    to?: RouteLocationRaw
+    /** @deprecated utiliser href à la place, link sera supprimé dans une version future */
+    link?: string
+    href?: string
+  }[]
   noArrow?: boolean
   horizontal?: boolean
   download?: boolean

--- a/src/components/DsfrCard/DsfrCard.vue
+++ b/src/components/DsfrCard/DsfrCard.vue
@@ -94,12 +94,12 @@ defineExpose({ goToTargetLink })
           class="fr-card__start"
         >
           <slot name="start-details" />
-          <p
+          <DsfrCardDetail
             v-if="detail"
-            class="fr-card__detail"
+            :icon="detailIcon"
           >
             {{ detail }}
-          </p>
+          </DsfrCardDetail>
         </div>
         <div
           v-if="$slots['end-details'] || endDetail"

--- a/src/components/DsfrCard/DsfrCard.vue
+++ b/src/components/DsfrCard/DsfrCard.vue
@@ -1,9 +1,9 @@
 <script lang="ts" setup>
 import { computed, ref } from 'vue'
 import DsfrButtonGroup from '../DsfrButton/DsfrButtonGroup.vue'
-
 import type { DsfrCardProps } from './DsfrCard.types'
 import DsfrCardDetail from './DsfrCardDetail.vue'
+import type { RouterLink } from 'vue-router'
 
 export type { DsfrCardProps }
 


### PR DESCRIPTION
L’icône de détail est maintenant implémentée au début et à la fin
dans le composant DsfrCard.
