### PR TITLE
Rendre obligatoire le paramètre `name` de DsfrRadioButtonSet

### DIFF
--- a/docs/gabarit-doc-composant.md
+++ b/docs/gabarit-doc-composant.md
@@ -1,0 +1,34 @@
+## 🌟 Introduction
+
+Ici la documentation de DSFR
+
+🏅 La documentation sur ... sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/<nom-dsfr>)
+
+<VIcon name="vi-file-type-storybook" /> La story sur ... sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfr<nom-composant>--docs)
+
+## 📐 Structure
+
+## 🛠️ Props
+
+## 📡 Événements
+
+## 🧩 Slots
+
+## 📝 Exemples
+
+## ⚙️ Code source du composant
+
+Dans le titre ## 📝 Exemples, je veux simplement ceci:
+
+::: code-group
+
+:::
+
+Et dans `## ⚙️ Code source du composant`, je veux ceci:
+
+::: code-group
+
+Dsfr.vue
+Dsfr.types.ts
+
+:::

--- a/src/components/DsfrRadioButton/DsfrRadioButton.types.ts
+++ b/src/components/DsfrRadioButton/DsfrRadioButton.types.ts
@@ -11,15 +11,15 @@ export type DsfrRadioButtonProps = {
 }
 
 export type DsfrRadioButtonSetProps = {
-  titleId?: string
-  disabled?: boolean
-  required?: boolean
-  small?: boolean
-  inline?: boolean
-  name?: string
-  errorMessage?: string
-  validMessage?: string
-  legend?: string
-  modelValue?: string | number | undefined
+  titleId?: string,
+  disabled?: boolean,
+  required?: boolean,
+  small?: boolean,
+  inline?: boolean,
+  name: string,
+  errorMessage?: string,
+  validMessage?: string,
+  legend?: string,
+  modelValue?: string | number | undefined,
   options?: Omit<DsfrRadioButtonProps, 'modelValue'>[]
 }

--- a/src/components/DsfrRadioButton/DsfrRadioButton.vue
+++ b/src/components/DsfrRadioButton/DsfrRadioButton.vue
@@ -7,7 +7,7 @@ import type { DsfrRadioButtonProps } from './DsfrRadioButton.types'
 export type { DsfrRadioButtonProps }
 
 const props = withDefaults(defineProps<DsfrRadioButtonProps>(), {
-  id: () => getRandomId('basic', 'checkbox'),
+  id: () => getRandomId('basic', 'radio'),
   modelValue: '',
   label: '',
   hint: '',

--- a/src/components/DsfrRadioButton/DsfrRadioButtonSet.spec.ts
+++ b/src/components/DsfrRadioButton/DsfrRadioButtonSet.spec.ts
@@ -67,6 +67,7 @@ describe('DsfrRadioButtonSet', () => {
         },
       },
       props: {
+        name: 'radio-button-set-name',
         errorMessage,
         options,
         legend,

--- a/src/components/DsfrRadioButton/DsfrRadioButtonSet.stories.ts
+++ b/src/components/DsfrRadioButton/DsfrRadioButtonSet.stories.ts
@@ -17,7 +17,7 @@ export default {
     },
     name: {
       control: 'text',
-      description: 'Valeur de l’attribut `name` de chaque bouton radio du groupe',
+      description: 'Valeur de l’attribut `name` de chaque bouton radio du groupe. Obligatoire.',
     },
     small: {
       control: 'boolean',

--- a/src/components/DsfrRadioButton/DsfrRadioButtonSet.vue
+++ b/src/components/DsfrRadioButton/DsfrRadioButtonSet.vue
@@ -13,7 +13,6 @@ const props = withDefaults(defineProps<DsfrRadioButtonSetProps>(), {
   errorMessage: '',
   validMessage: '',
   legend: '',
-  name: 'no-name',
   options: () => [],
 })
 


### PR DESCRIPTION
- **fix(DsfrRadioButtonSet): 🐛 rend obligatoire la prop name**
- **chore: 📝 ajoute un gabarit pour doc de composant**
