### PR TITLE
fix: 🐛 supprime la balise nav de DsfrHeader

### DIFF
--- a/src/components/DsfrHeader/DsfrHeader.vue
+++ b/src/components/DsfrHeader/DsfrHeader.vue
@@ -169,13 +169,11 @@ defineEmits<{
               v-if="quickLinks?.length"
               class="fr-header__tools-links"
             >
-              <nav role="navigation">
-                <DsfrHeaderMenuLinks
-                  v-if="!menuOpened"
-                  :links="quickLinks"
-                  :nav-aria-label="quickLinksAriaLabel"
-                />
-              </nav>
+              <DsfrHeaderMenuLinks
+                v-if="!menuOpened"
+                :links="quickLinks"
+                :nav-aria-label="quickLinksAriaLabel"
+              />
             </div>
             <div
               v-if="showSearch"


### PR DESCRIPTION
... car elle est déjà présente dans le composant DsfrHeaderMenuLinks
