### PR TITLE
fix: callout title is optional

### DIFF
--- a/src/components/DsfrCallout/DsfrCallout.stories.ts
+++ b/src/components/DsfrCallout/DsfrCallout.stories.ts
@@ -105,6 +105,40 @@ export const MiseEnAvant = (args) => ({
   `,
 
 })
+
+export const MiseEnAvantSansTitre = (args) => ({
+  components: {
+    DsfrCallout,
+    VIcon,
+  },
+
+  data () {
+    return {
+      ...args,
+      button: args.button && {
+        ...args.button,
+        onClick: args.onClick,
+      },
+    }
+  },
+
+  template: `
+    <DsfrCallout
+      :content="content"
+      :button="button"
+      :icon="icon"
+      :title-tag="titleTag"
+    />
+  `,
+
+})
+MiseEnAvantSansTitre.args = {
+  button: undefined,
+  icon: '',
+  content: 'Lorem ipsum dolor sit amet, consectetur adipiscing, incididunt, ut labore et dol',
+  titleTag: undefined,
+}
+
 const buttonOnclick = fn()
 MiseEnAvant.args = {
   title: 'Titre de la mise en avant',

--- a/src/components/DsfrCallout/DsfrCallout.types.ts
+++ b/src/components/DsfrCallout/DsfrCallout.types.ts
@@ -2,7 +2,7 @@ import type { OhVueIcon as VIcon } from 'oh-vue-icons'
 import type { DsfrButtonProps } from '../DsfrButton/DsfrButton.types'
 
 export type DsfrCalloutProps = {
-  title: string
+  title?: string
   content: string
   titleTag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
   button?: DsfrButtonProps

--- a/src/components/DsfrCallout/DsfrCallout.vue
+++ b/src/components/DsfrCallout/DsfrCallout.vue
@@ -28,6 +28,7 @@ const iconProps = computed(() => dsfrIcon.value ? undefined : typeof props.icon 
       v-bind="iconProps"
     />
     <component
+      v-if="title"
       :is="titleTag"
       class="fr-callout__title"
     >


### PR DESCRIPTION
- DsfrCallout

Sur le DSFR, le titre de la mise en avant est optionnel
[https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/mise-en-avant](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/mise-en-avant)