### PR TITLE
fix(DsfrTooltip): 🐛 prend en compte le parent

### DIFF
--- a/demo-app/views/AppHome.vue
+++ b/demo-app/views/AppHome.vue
@@ -69,6 +69,8 @@ const onClick = () => {
     isLoading.value = false
   }, 2000)
 }
+
+const expandedId = ref('')
 </script>
 
 <template>
@@ -107,6 +109,23 @@ const onClick = () => {
   <h2 class="fr-mt-4w">
     Infobulles
   </h2>
+
+  <div>
+    <DsfrAccordion
+      id="accordion-1"
+      style="position: relative;"
+      title="Accordéon avec infobulle"
+      :expanded-id="expandedId"
+      @expand="expandedId = $event"
+    >
+      Test infobulle dans accordéon
+      <DsfrTooltip
+
+        content="Texte de l’info-bulle qui apparaît au survol"
+      />
+    </DsfrAccordion>
+  </div>
+
   <div class="flex justify-between w-full relative">
     <DsfrTooltip
       on-hover

--- a/src/components/DsfrTooltip/DsfrTooltip.vue
+++ b/src/components/DsfrTooltip/DsfrTooltip.vue
@@ -31,10 +31,10 @@ async function computePosition () {
   }
 
   await new Promise(resolve => setTimeout(resolve, 100))
-  const sourceTop = (source.value?.offsetTop as number) - window.scrollY
+  const sourceTop = source.value?.getBoundingClientRect().top as number
   const sourceHeight = source.value?.offsetHeight as number
   const sourceWidth = source.value?.offsetWidth as number
-  const sourceLeft = (source.value?.offsetLeft as number) - window.scrollX
+  const sourceLeft = source.value?.getBoundingClientRect().left as number
   const tooltipHeight = tooltip.value?.offsetHeight as number
   const tooltipWidth = tooltip.value?.offsetWidth as number
   const isSourceAtTop = (sourceTop - tooltipHeight) < 0


### PR DESCRIPTION
Prend en compte le parent pour la position du tooltip.
Si l’info-bulle est dans un élément relatif, sa position le prend en compte désormais.
