### PR TITLE
feat(DsfrRadioButton): ✨ ajout svg

### DIFF
--- a/src/components/DsfrRadioButton/DsfrRadioButton.md
+++ b/src/components/DsfrRadioButton/DsfrRadioButton.md
@@ -14,43 +14,50 @@ Le bouton radio ne peut pas être utilisé seul : il faut au minimum 2 options. 
 
 Les boutons radio riches permettent de sélectionner un choix parmi une liste d’options illustrées. À la différence du bouton radio simple, l’image permet d’illustrer et d’accompagner l’utilisateur dans son choix.
 
+Concernant les images, elles peuvent être des artworks/pictogrammes au format SVG. Il faut alors se référer [aux fondamentaux techniques du DSFR pour la définition des SVG](https://www.systeme-de-design.gouv.fr/elements-d-interface/fondamentaux-techniques/pictogramme).
+
 🏅 La documentation sur le [bouton radio](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/bouton-radio) et le [bouton radio riche](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/bouton-radio-riche) sur le DSFR
 
 <VIcon name="vi-file-type-storybook" /> La story sur le bouton radio sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrradiobutton--docs)
 
 ## 📐 Structure
 
-Le composant `DsfrRadioButtonSet` est composé des éléments suivants :
+Le composant `DsfrRadioButton` est composé des éléments suivants :
 
-- Un élément `<div>` englobant l'ensemble du groupe de radio.
-- Une légende (`legend`) définie par la prop `legend` et personnalisable avec le slot `legend`.
-- Un groupe de boutons radio individuels rendus par le composant `DsfrRadioButton`.
-- Un message d'information, d'erreur ou de validation, affiché en dessous du groupe de boutons radio (facultatif).
+- Un élément `<div>` englobant l'ensemble des éléments du bouton radio
+- Un input (`input`) définie par différentes propriétés.
+- Un label avec un message descriptif optionnel.
+- Une image optionnelle (`img` ou `svg`) en fonction des propriétés renseignées
 
 ## 🛠️ Props
 
-| Nom                   | Type                                    | Description                                                   | Obligatoire |
-|-----------------------|-------------------------------------------|----------------------------------------------------------------|--------------|
-| `name`                  | *`string`*                                 | Nom du champ `<input>` associé à l'ensemble des boutons radio     | ✅           |
-| `modelValue`           | *`string`* ou *`number`* ou *`boolean`*                       | Valeur courante du composant (sélection courante)                 |     ✅      |
-| `inline`                | *`boolean`*                                | Affiche le bouton radio en ligne (par défaut : `false`)            |           |
-| `id`                  | *`string`*                                 | Id du champ `<input>` (par défaut: `undefined`)     |            |
-| `id`                  | *`string`*                                 | Id du champ `<input>` (par défaut: `undefined`)     |            |
-| `small`                 | *`boolean`*                                | Affiche les boutons radio en taille réduite (par défaut : `false`)                     |           |
+| Nom          | Type                                                     | Description                                                   | Valeur par défaut                                         | Obligatoire            |
+|--------------|----------------------------------------------------------|---------------------------------------------------------------|-----------------------------------------------------------|------------------------|
+| `name`       | *`string`*                                               | Nom du champ `<input>` associé à l'ensemble des boutons radio |                                                           | ✅                      |
+| `modelValue` | *`string`* ou *`number`* ou *`boolean`* ou *`undefined`* | Valeur courante du composant (sélection courante)             | `''`                                                      | ✅                      |
+| `label`      | *`string`*                                               | Libellé du bouton radio                                       | `''`                                                      | ✅                      |
+| `hint`       | *`string`*                                               | Descriptif du bouton radio                                    | `''`                                                      | ✅                      |
+| `inline`     | *`boolean`*                                              | Affiche le bouton radio en ligne                              | `false`                                                   |                        |
+| `id`         | *`string`*                                               | Id du champ `<input>`                                         | `undefined`                                               |                        |
+| `small`      | *`boolean`*                                              | Affiche le bouton radio en taille réduite                     | `false`                                                   |                        |
+| `disabled`   | *`boolean`*                                              | Indique si le bouton radio est désactivé.                     | `false`                                                   |                        |
+| `img`        | *`string`*                                               | Source de l'image à afficher.                                 | `undefined`                                               |                        |
+| `svgPath`    | *`string`*                                               | Chemin vers le SVG à afficher.                                | `undefined`                                               |                        |
+| `svgAttrs`   | *`Record<string, unknown>`*                              | Chemin vers le SVG à afficher.                                | `{ viewBox: '0 0 80 80', width: '80px', height: '80px' }` | Attributs pour le SVG. |
 
 ## 📡 Événements
 
-`DsfrRadioButtonSet` émet l'événement suivant :
+`DsfrRadioButton` émet l'événement suivant :
 
-| Nom                  | Description                                         |
-|-----------------------|----------------------------------------------------|
-| `update:modelValue`   | Est émis lorsque la valeur d'un bouton radio est sélectionnée |
+| Nom                 | Description                                                 |
+|---------------------|-------------------------------------------------------------|
+| `update:modelValue` | Est émis lorsque la valeur du bouton radio est sélectionnée |
 
 ## 🧩 Slots
 
-`DsfrRadioButtonSet` fournit les slots suivants pour la personnalisation :
+`DsfrRadioButton` fournit les slots suivants pour la personnalisation :
 
-- `legend` : Permet de personnaliser le contenu de la légende.
+- `label` : Permet de personnaliser le contenu de la légende.
 - `required-tip` : Permet d'ajouter un astérisque indiquant que le champ est obligatoire (fonctionne uniquement si l'attribut `required` est défini sur le composant).
 
 ## 🪆 Relation avec `DsfrRadioButtonSet`
@@ -73,7 +80,7 @@ Le composant [`DsfrRadioButtonSet`](./DsfrRadioButtonSet.md) utilise le composan
 
 ::: code-group
 
-<<< DsfrRadioButtonSet.vue
+<<< DsfrRadioButton.vue
 <<< DsfrRadioButton.types.ts
 
 :::

--- a/src/components/DsfrRadioButton/DsfrRadioButton.stories.ts
+++ b/src/components/DsfrRadioButton/DsfrRadioButton.stories.ts
@@ -3,6 +3,8 @@ import DsfrRadioButtonSet from './DsfrRadioButtonSet.vue'
 
 /**
  * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/boutons-radio)
+ *
+ * Nous vous invitons à regarder plutôt la [nouvelle documentation](https://vue-ds.fr/composants/DsfrRadioButton) pour ce composant
  */
 export default {
   component: DsfrRadioButton,
@@ -32,6 +34,14 @@ export default {
     img: {
       control: 'text',
       description: 'Permet d\'ajouter une image au composant',
+    },
+    svgPath: {
+      control: 'text',
+      description: 'Chemin vers le SVG à afficher. (doit respecter les fondamentaux techniques pour les pictogrammes du DSFR)',
+    },
+    svgAttrs: {
+      control: 'object',
+      description: 'Permet de définir des attributs pour le SVG.',
     },
     'update:modelValue': {
       description: 'Événement émis à chaque changement de valeur du groupe de même bouton radio',

--- a/src/components/DsfrRadioButton/DsfrRadioButton.types.ts
+++ b/src/components/DsfrRadioButton/DsfrRadioButton.types.ts
@@ -9,6 +9,8 @@ export type DsfrRadioButtonProps = {
   label?: string
   hint?: string
   img?: string
+  svgPath?: string
+  svgAttrs?: Record<string, unknown>
 }
 
 export type DsfrRadioButtonOptions = (Omit<DsfrRadioButtonProps, 'modelValue'>)[]

--- a/src/components/DsfrRadioButton/DsfrRadioButton.vue
+++ b/src/components/DsfrRadioButton/DsfrRadioButton.vue
@@ -11,12 +11,16 @@ const props = withDefaults(defineProps<DsfrRadioButtonProps>(), {
   modelValue: '',
   label: '',
   hint: '',
-  img: '',
+  img: undefined,
+  svgPath: undefined,
+  svgAttrs: () => ({ viewBox: '0 0 80 80', width: '80px', height: '80px' }),
 })
 
 defineEmits<{ (e: 'update:modelValue', payload: string | number | boolean): void }>()
 
-const rich = computed(() => !!props.img)
+const defaultSvgAttrs = { viewBox: '0 0 80 80', width: '80px', height: '80px' }
+
+const rich = computed(() => !!props.img || !!props.svgPath)
 </script>
 
 <template>
@@ -65,13 +69,34 @@ const rich = computed(() => !!props.img)
         </span>
       </label>
       <div
-        v-if="img"
+        v-if="img || svgPath"
         class="fr-radio-rich__pictogram"
       >
         <img
+          v-if="img"
           :src="img"
+          class="fr-artwork"
           alt=""
         >
+        <svg
+          v-else
+          aria-hidden="true"
+          class="fr-artwork"
+          v-bind="{ ...defaultSvgAttrs, ...svgAttrs }"
+        >
+          <use
+            class="fr-artwork-decorative"
+            :href="`${svgPath}#artwork-decorative`"
+          />
+          <use
+            class="fr-artwork-minor"
+            :href="`${svgPath}#artwork-minor`"
+          />
+          <use
+            class="fr-artwork-major"
+            :href="`${svgPath}#artwork-major`"
+          />
+        </svg>
       </div>
     </div>
   </div>

--- a/src/components/DsfrRadioButton/DsfrRadioButtonSet.md
+++ b/src/components/DsfrRadioButton/DsfrRadioButtonSet.md
@@ -20,19 +20,19 @@ Le composant `DsfrRadioButtonSet` est composé des éléments suivants :
 
 ## 🛠️ Props
 
-| Nom                   | Type                                    | Description                                                       | Obligatoire |
-|-----------------------|------------------------------------------|-------------------------------------------------------------------|--------------|
-| `titleId`               | *`string`*                                 | Identifiant unique du champ (générée automatiquement si non fournie) | Non          |
-| `disabled`              | *`boolean`*                                 | Indique si l'ensemble des boutons radio est désactivé           | Non          |
-| `required`              | *`boolean`*                                 | Indique si le groupe de radio est obligatoire                    | Non          |
-| `small`                 | *`boolean`*                                 | Affiche les boutons radio en taille réduite                     | Non          |
-| `inline`                | *`boolean`*                                 | Affiche les boutons radio en ligne (par défaut : non)            | Non          |
-| `name`                  | *`string`*                                 | Nom du champ `<input>` associé à l'ensemble des boutons radio du tableau données dans la prop `options`, cf. plus loin     | Oui           |
-| `errorMessage`         | *`string`*                                 | Message d'erreur global à afficher                               | Non          |
-| `validMessage`         | *`string`*                                 | Message de validation global à afficher                           | Non          |
-| `legend`                | *`string`*                                 | Texte de la légende                                               | Non          |
-| `modelValue`           | *`string`* ou *`number`* ou *`boolean`*                       | Valeur courante du composant (sélection courante)                 | Non          |
-| `options`               | *`Omit<DsfrRadioButtonProps, 'modelValue'>[]`* | Tableau d'options définissant les boutons radio individuels       | Oui           |
+| Nom            | Type                                           | Description                                                                                                            | Obligatoire |
+|----------------|------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|-------------|
+| `titleId`      | *`string`*                                     | Identifiant unique du champ (générée automatiquement si non fournie)                                                   | Non         |
+| `disabled`     | *`boolean`*                                    | Indique si l'ensemble des boutons radio est désactivé                                                                  | Non         |
+| `required`     | *`boolean`*                                    | Indique si le groupe de radio est obligatoire                                                                          | Non         |
+| `small`        | *`boolean`*                                    | Affiche les boutons radio en taille réduite                                                                            | Non         |
+| `inline`       | *`boolean`*                                    | Affiche les boutons radio en ligne (par défaut : non)                                                                  | Non         |
+| `name`         | *`string`*                                     | Nom du champ `<input>` associé à l'ensemble des boutons radio du tableau données dans la prop `options`, cf. plus loin | Oui         |
+| `errorMessage` | *`string`*                                     | Message d'erreur global à afficher                                                                                     | Non         |
+| `validMessage` | *`string`*                                     | Message de validation global à afficher                                                                                | Non         |
+| `legend`       | *`string`*                                     | Texte de la légende                                                                                                    | Non         |
+| `modelValue`   | *`string`* ou *`number`* ou *`boolean`*        | Valeur courante du composant (sélection courante)                                                                      | Non         |
+| `options`      | *`Omit<DsfrRadioButtonProps, 'modelValue'>[]`* | Tableau d'options définissant les boutons radio individuels                                                            | Oui         |
 
 ::: warning Important
 
@@ -195,9 +195,9 @@ const options = [
 
 `DsfrRadioButtonSet` émet l'événement suivant :
 
-| Nom                  | Description                                         |
-|-----------------------|----------------------------------------------------|
-| `update:modelValue`   | Est émis lorsque la valeur d'un bouton radio est sélectionnée |
+| Nom                 | Description                                                   |
+|---------------------|---------------------------------------------------------------|
+| `update:modelValue` | Est émis lorsque la valeur d'un bouton radio est sélectionnée |
 
 ## 🧩 Slots
 


### PR DESCRIPTION
Related issue #832 

J'aurai aimé pouvoir faire un test / ajout dans la doc avec des SVG du DSFR mais je ne vois pas où les positionner pour éviter qu'il soit embarqué dans le package vue-dsfr.  
Ca vaudrait aussi le coup, d'avoir une doc mdx sur les artworks https://github.com/GouvernementFR/dsfr/tree/main/src/core/asset/artwork