### PR TITLE
fix: 🐛 corrige erreur lorsque touche préssée avec focus sur dsfrTabItem

### DIFF
--- a/src/components/DsfrTabs/DsfrTabItem.vue
+++ b/src/components/DsfrTabs/DsfrTabItem.vue
@@ -36,9 +36,11 @@ const keyToEventDict = {
 } as const
 
 function onKeyDown (event: KeyboardEvent) {
-  const key = event.key as keyof typeof keyToEventDict
-  // @ts-expect-error 2769
-  emit(keyToEventDict[key])
+  if (keyToEventDict[keyToEventDict[event.key]]) {
+    const key = event.key as keyof typeof keyToEventDict
+    // @ts-expect-error 2769
+    emit(keyToEventDict[key])
+  }
 }
 </script>
 


### PR DESCRIPTION
Prevent un emit undefined

(Pas possible de pr sur develop car le code en question n'est pas dessus)

fix: https://github.com/dnum-mi/vue-dsfr/issues/827