### PR TITLE
fix(DsfrTooltip): 🐛 empêche la propagation du clic

### DIFF
--- a/src/components/DsfrTooltip/DsfrTooltip.vue
+++ b/src/components/DsfrTooltip/DsfrTooltip.vue
@@ -124,7 +124,7 @@ const onClick = () => {
     :class="onHover ? 'fr-link' : 'fr-btn  fr-btn--tooltip'"
     :aria-describedby="id"
     :href="onHover ? '#' : undefined"
-    @click="onClick()"
+    @click.stop="onClick()"
     @mouseenter="onMouseEnter()"
     @mouseleave="onMouseLeave()"
   >


### PR DESCRIPTION
Salut l’équipe vue-dsfr,

Je constate que si je veux ajouter un tooltip dans le header d’une data-table, lorsque je cliquerais sur le tooltip, je vais également déclencher le tri de ma colonne.

Le fix me semble être assez simple, il suffirait de rajouter un modificateur d’évènement sur le `@click` du composant
https://github.com/dnum-mi/vue-dsfr/blob/main/src/components/DsfrTooltip/DsfrTooltip.vue#L127
Un `@click.stop` devrait faire l’affaire

Merci par avance et bonne journée :)