### PR TITLE
fix: 🐛 double balise nav dans le DsfrHeader en mobile

### DIFF
--- a/src/components/DsfrHeader/DsfrHeader.vue
+++ b/src/components/DsfrHeader/DsfrHeader.vue
@@ -242,15 +242,13 @@ provide(registerNavigationLinkKey, () => {
                   @select="languageSelector.currentLanguage = $event.codeIso"
                 />
               </template>
-              <nav role="navigation">
-                <DsfrHeaderMenuLinks
-                  v-if="menuOpened"
-                  role="navigation"
-                  :links="quickLinks"
-                  :nav-aria-label="quickLinksAriaLabel"
-                  @link-click="onQuickLinkClick"
-                />
-              </nav>
+              <DsfrHeaderMenuLinks
+                v-if="menuOpened"
+                role="navigation"
+                :links="quickLinks"
+                :nav-aria-label="quickLinksAriaLabel"
+                @link-click="onQuickLinkClick"
+              />
             </div>
 
             <template v-if="modalOpened">


### PR DESCRIPTION
Salut la team vue-dsfr,

Il me semble qu’il y a une coquille en mobile sur ce composant, la balise `nav` est posée à la fois manuellement et à la fois par le composant `DsfrHeaderMenuLinks`.

Merci par avance et bonne journée :)