### PR TITLE
fix: 🐛 la fonction de tri par défaut sur le DsfrDataTable

### DIFF
--- a/src/components/DsfrDataTable/DsfrDataTable.vue
+++ b/src/components/DsfrDataTable/DsfrDataTable.vue
@@ -65,7 +65,7 @@ const lowestLimit = computed(() => currentPage.value * rowsPerPage.value)
 const highestLimit = computed(() => (currentPage.value + 1) * rowsPerPage.value)
 
 function defaultSortFn (a: string | DsfrDataTableRow, b: string | DsfrDataTableRow) {
-  const key = props.sorted as string
+  const key = sortedBy.value
   // @ts-expect-error TS7015
   if (((a as DsfrDataTableRow)[key] ?? a) < ((b as DsfrDataTableRow)[key] ?? b)) {
     return -1
@@ -77,7 +77,7 @@ function defaultSortFn (a: string | DsfrDataTableRow, b: string | DsfrDataTableR
   return 0
 }
 
-const sortedBy = defineModel<string | undefined>('sortedBy', { default: undefined })
+const sortedBy = defineModel<string>('sortedBy', { default: props.sorted })
 const sortedDesc = defineModel('sortedDesc', { default: false })
 function sortBy (key: string) {
   if (!props.sortableRows || (Array.isArray(props.sortableRows) && !props.sortableRows.includes(key))) {


### PR DESCRIPTION
Hello vue-dsfr,

Le tri ne fonctionne pas comme attendu sur le DsfrDataTable, en effet dans la méthode de tri par défaut c’est toujours le `props.sorted` qui sert pour déterminer quel clé est utilisée. C’est plutôt `sortedBy.value` qui devrait être utilisé.

J’ajoute (non corrigé ici) que le tri ne fonctionne pas pour les colonnes qui ont une `key` (dans la définition des colonnes) qui ne correspond pas à un attribut de l’objet, et il est impossible d’avoir un tri fonctionnel sur ces colonnes actuellement.