### PR TITLE
fix: :bug: blocked select when only one choice and not selected option

### DIFF
--- a/src/components/DsfrSelect/DsfrSelect.vue
+++ b/src/components/DsfrSelect/DsfrSelect.vue
@@ -71,7 +71,7 @@ const messageType = computed(() => {
       @change="$emit('update:modelValue', ($event.target as HTMLInputElement)?.value)"
     >
       <option
-        :selected="modelValue == null"
+        :selected="modelValue == null || !options.some(option => typeof option !== 'object' ? option !== modelValue : option.value === modelValue)"
         disabled
         hidden
       >


### PR DESCRIPTION
Si il n'y a qu'une seule option et que le modelValue ne correspond pas, alors seulement l'option disponible est affichée mais il n'y a pas moyen de mettre à jour le choix et donc aucun emit.