### PR TITLE
feat(DsfrNavigation): :bug: ajoute de l'attribut `id` au composant `DsfrNavigationItem` depuis le composant `DsfrNavigation`

### DIFF
--- a/demo-app/App.vue
+++ b/demo-app/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, useId } from 'vue'
 import { useRoute } from 'vue-router'
 
 import DsfrBreadcrumb from '../src/components/DsfrBreadcrumb/DsfrBreadcrumb.vue'
@@ -64,6 +64,7 @@ const quickLinks: DsfrHeaderProps['quickLinks'] = [
 const route = useRoute()
 const navItems: DsfrNavigationProps['navItems'] = [
   {
+    id: useId(),
     to: { name: 'Home' },
     text: 'Accueil',
   },

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "@iconify/vue": "^4.1.2",
-    "vue": "^3.4.38",
+    "vue": "^3.5.13",
     "vue-router": "^4.4.3"
   },
   "dependencies": {

--- a/src/components/DsfrNavigation/DsfrNavigation.vue
+++ b/src/components/DsfrNavigation/DsfrNavigation.vue
@@ -78,6 +78,7 @@ onUnmounted(() => {
       <slot />
       <DsfrNavigationItem
         v-for="(navItem, idx) of navItems"
+        :id="navItem.id"
         :key="idx"
       >
         <DsfrNavigationMenuLink

--- a/src/components/DsfrNavigation/DsfrNavigationItem.spec.ts
+++ b/src/components/DsfrNavigation/DsfrNavigationItem.spec.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/vue'
 // import '@gouvfr/dsfr/dist/core/core.module.js'
-import { useId } from 'vue-demi'
+import { useId } from 'vue'
 
 import DsfrNavigationItem from './DsfrNavigationItem.vue'
 

--- a/src/components/DsfrNavigation/DsfrNavigationItem.spec.ts
+++ b/src/components/DsfrNavigation/DsfrNavigationItem.spec.ts
@@ -1,13 +1,17 @@
 import { render } from '@testing-library/vue'
 // import '@gouvfr/dsfr/dist/core/core.module.js'
+import { useId } from 'vue-demi'
 
 import DsfrNavigationItem from './DsfrNavigationItem.vue'
 
 describe('DsfrNavigationItem', () => {
   it('should render a navigation item', () => {
     const content = 'Contenu d’un item de menu de navigation'
-
+    const id = useId()
     const { getByText } = render(DsfrNavigationItem, {
+      props: {
+        id,
+      },
       slots: {
         default: content,
       },
@@ -18,5 +22,6 @@ describe('DsfrNavigationItem', () => {
     expect(liEl).toHaveClass('fr-nav__item')
     expect(liEl).not.toHaveClass('fr-nav__item--active')
     expect(liEl).toHaveAttribute('id')
+    expect(liEl.id).toBe(id)
   })
 })


### PR DESCRIPTION
Cette pull request introduit l'utilisation d'ID pour les éléments de navigation dans le composant  `DsfrNavigation` et met à jour la demo et les tests pertinents en conséquence.

### Introduction des IDs :

* Passage de l'ID unique au composant `DsfrNavigationItem` dans `src/components/DsfrNavigation/DsfrNavigation.vue`.

### Mises à jour de la demo :

* Ajout de l'importation de `useId` dans `demo-app/App.vue` pour générer des IDs uniques pour les éléments de navigation.
* Mise à jour de `navItems` dans `demo-app/App.vue` pour inclure des IDs uniques en utilisant `useId()`.

### Mises à jour des tests :

* Importation de `useId` dans `DsfrNavigationItem.spec.ts` pour générer des IDs uniques pour les tests.
* Mise à jour des cas de test dans `DsfrNavigationItem.spec.ts` pour vérifier la présence et la justesse de l'ID unique.
