### PR TITLE
fix: 🐛 utilisation native de l'ancre pour les liens d'évitement

### DIFF
--- a/src/components/DsfrSkipLinks/DsfrSkipLinks.vue
+++ b/src/components/DsfrSkipLinks/DsfrSkipLinks.vue
@@ -26,7 +26,7 @@ const scrollMeTo = (elementId: string) => {
           <a
             class="fr-link"
             :href="`#${link.id}`"
-            @click.prevent="scrollMeTo(link.id)"
+            @click="scrollMeTo(link.id)"
           >{{ link.text }}</a>
         </li>
       </ul>


### PR DESCRIPTION
Bonjour l'équipe DSFR,

Je vous fais cette petite PR car on a remarqué avec mon équipe de dev que le composant DsfrSkipLinks empêche le fonctionnement natif du lien (par navigation clavier ou par lien).
Cela empêche aussi de se retrouver au contenu en cas de rechargement de page.

Je n'ai pas trouvé d'effet de bord négatif à enlever le prevent.

(nouvelle PR car nouvelle branche pour garder main sur le flow GIT de votre repo)