### PR TITLE
fix: 🐛 DsfrCallout description critere 8.9 RGAA 4.1.2 NC

### DIFF
--- a/src/components/DsfrCallout/DsfrCallout.types.ts
+++ b/src/components/DsfrCallout/DsfrCallout.types.ts
@@ -3,7 +3,7 @@ import type { VIconProps } from '../VIcon/VIcon.vue'
 
 export type DsfrCalloutProps = {
   title?: string
-  content: string
+  content?: string
   titleTag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
   button?: DsfrButtonProps
   icon?: string | VIconProps

--- a/src/components/DsfrCallout/DsfrCallout.vue
+++ b/src/components/DsfrCallout/DsfrCallout.vue
@@ -36,7 +36,10 @@ const iconProps = computed(() => dsfrIcon.value ? undefined : typeof props.icon 
       {{ title }}
     </component>
 
-    <p class="fr-callout__text">
+    <p
+      v-if="content"
+      class="fr-callout__text"
+    >
       {{ content }}
     </p>
 
@@ -46,7 +49,12 @@ const iconProps = computed(() => dsfrIcon.value ? undefined : typeof props.icon 
     />
 
     <!-- @slot Slot par défaut pour le contenu de la mise en avant. Sera dans `<div class="fr-callout">` -->
-    <slot />
+    <div
+      v-if="$slots.default"
+      :class="['fr-callout__default', { 'fr-callout__text': !content }]"
+    >
+      <slot />
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION
Bonjour à tous,

Une petite modification du DsfrCallout car on a eu une NC sur le critère [8.9 RGAA](https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#8.9) et ça nous a posé reflexion.

Dans notre cas, nous utilisons le slot par default pour la description obligatoire et nous n'utilisons pas la props `content`.
Sauf que dans votre implémentation cette description obligatoire se situe dans la balise `<p class="fr-callout__text">`.
On se retrouve de notre côté avec une balise vide qui remonte en NC.

Dans l'implémentation que je propose, on teste si `content` est défini, si oui, le comportement actuel est conservé, sinon `fr-callout_text` devient une classe du wrapper du `slot` par défaut.

Et si on a et `props.content` et `$slots.default`, alors la balise p sera la détentrice du `fr-callout_text` pour la description, et le slot par défault un simple contenu additionnel.

Au final, on respecte les spécifications DSFR du composant ["Mise en avant"](https://www.systeme-de-design.gouv.fr/composants-et-modeles/composants/mise-en-avant) et on ne remonte pas de NC RGAA.

Merci pour votre lecture !