### PR TITLE
fix: 🐛 DsfrSideMenu balise titre RGAA 8.9.1 NC

### DIFF
--- a/src/components/DsfrSideMenu/DsfrSideMenu.types.ts
+++ b/src/components/DsfrSideMenu/DsfrSideMenu.types.ts
@@ -9,6 +9,7 @@ export type DsfrSideMenuProps = {
   collapseValue?: string
   menuItems?: DsfrSideMenuListItemProps[]
   headingTitle?: string
+  titleTag?: string
 }
 
 export type DsfrSideMenuButtonProps = {

--- a/src/components/DsfrSideMenu/DsfrSideMenu.vue
+++ b/src/components/DsfrSideMenu/DsfrSideMenu.vue
@@ -17,6 +17,7 @@ withDefaults(defineProps<DsfrSideMenuProps>(), {
   // @ts-expect-error this is really undefined
   menuItems: () => undefined,
   headingTitle: '',
+  titleTag: 'h3',
 })
 
 defineEmits<{ (e: 'toggleExpand', payload: string): void }>()
@@ -65,9 +66,12 @@ watch(expanded, (newValue, oldValue) => {
         }"
         @transitionend="onTransitionEnd(expanded)"
       >
-        <div class="fr-sidemenu__title">
+        <component
+          :is="titleTag"
+          class="fr-sidemenu__title"
+        >
           {{ headingTitle }}
-        </div>
+        </component>
         <!-- @slot Slot par défaut du contenu du menu latéral -->
         <slot>
           <DsfrSideMenuList


### PR DESCRIPTION
Hello (it's me again),

Autre composant qui nous remonte une [anomalie RGAA](https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#8.9.1) et qui est présente sur le DSFR de base, le [Menu Latéral](https://www.systeme-de-design.gouv.fr/composants-et-modeles/composants/menu-lateral).

Dans notre implémentation, la recommandation est de mettre un `<h2>`, mais je pense que de laisser la liberté au développeur de choisir son tag est plus pertinent.

Merci d'avance !