### PR TITLE
fix: 🐛 DsfrAccordion shouldn't focus on toggle

### DIFF
--- a/src/components/DsfrAccordion/DsfrAccordion.vue
+++ b/src/components/DsfrAccordion/DsfrAccordion.vue
@@ -76,7 +76,7 @@ watch(isActive, (newValue, oldValue) => {
         'fr-collapse--expanded': cssExpanded, // Need to use a separate data to add/remove the class after a RAF
         'fr-collapsing': collapsing,
       }"
-      @transitionend="onTransitionEnd(isActive)"
+      @transitionend="onTransitionEnd(isActive, false)"
     >
       <!-- @slot Slot par défaut pour le contenu de l’accordéon: sera dans `<div class="fr-collapse">` -->
       <slot />

--- a/src/composables/useCollapsable.ts
+++ b/src/composables/useCollapsable.ts
@@ -48,13 +48,16 @@ export const useCollapsable = () => {
   }
 
   /**
-   * @see https://github.com/GouvernementFR/dsfr/blob/main/src/core/script/collapse/collapse.js#L25
+   * @see https://github.com/GouvernementFR/dsfr/blob/main/src/dsfr/core/script/collapse/collapse.js#L25
    * @param {boolean} expanded
+   * @param {boolean} focusFirstAnchor
    * @return void
    */
-  const onTransitionEnd = (expanded: boolean): void => {
+  const onTransitionEnd = (expanded: boolean, focusFirstAnchor: boolean = true): void => {
     collapsing.value = false
-    collapse.value?.querySelector('a')?.focus()
+    if (focusFirstAnchor) {
+      collapse.value?.querySelector('a')?.focus()
+    }
     if (collapse.value && expanded === false) {
       collapse.value.style.removeProperty('--collapse-max-height')
     }


### PR DESCRIPTION
Bonsoir,

Suite à un bug remonté avec la mise à jour 7.2.0 sur un focus de lien à l'ouverture d'un accordéon et à [l'issue 999](https://github.com/dnum-mi/vue-dsfr/issues/999), je propose ce correctif.

Il permet de, au choix, ne pas focus le premier lien que le composant utilisant le composable `onTransitionEnd` pourrait posséder.

Dans le cas du `DsfrAccordion.vue`, il amène un comportement non désiré et provoque une anomalie en terme d'accessibilité en faisant ignorer du contenu par les lecteurs d'écran.

Une très bonne soirée 