### PR TITLE
fix: :label: Met à jour les types des composants DsfrCheckbox et DsfrCheckboxSet

### DIFF
--- a/src/components/DsfrCheckbox/DsfrCheckbox.types.ts
+++ b/src/components/DsfrCheckbox/DsfrCheckbox.types.ts
@@ -6,7 +6,7 @@ export type DsfrCheckboxProps = {
   required?: boolean
   value: unknown
   checked?: boolean
-  modelValue: Array<unknown>
+  modelValue: boolean
   small?: boolean
   inline?: boolean
   label?: string
@@ -14,6 +14,8 @@ export type DsfrCheckboxProps = {
   validMessage?: string
   hint?: string
 }
+
+export type DsfrCheckboxSetOptions = (Omit<DsfrCheckboxProps, 'modelValue'> & InputHTMLAttributes)[]
 
 export type DsfrCheckboxSetProps = {
   titleId?: string
@@ -24,7 +26,7 @@ export type DsfrCheckboxSetProps = {
   errorMessage?: string
   validMessage?: string
   legend?: string
-  options?: (DsfrCheckboxProps & InputHTMLAttributes)[]
+  options?: (Omit<DsfrCheckboxProps, 'modelValue'> & InputHTMLAttributes)[]
   modelValue?: Array<unknown>
   ariaInvalid?: boolean
 }


### PR DESCRIPTION
- **fix: 🏷️ Change le type de la propriété modelValue du composant DsfrCheckboxProps vers un booléen**
Celui-ci utilise actuellement un tableau de strings, contrairement à ce qui est décrit dans la doc

- **fix: 🏷️ Change le type de la propriété 'options' du composant DsfrCheckboxSetProps**
Lorsque le modelValue est défini au niveau du checkbox set parent, l'option modelValue de l'enfant ne devrait pas être obligatoire

- **feat: 🏷️ Expose le type DsfrCheckboxSetOptions**
Similaire au type exposé par le composant DsfrRadioButtonSet