### PR TITLE
docs: 📝 corrige vite.config.ts suite à montée version 7.x -> 8.x

### DIFF
--- a/docs/guide/pour-commencer.md
+++ b/docs/guide/pour-commencer.md
@@ -207,7 +207,7 @@ import Components from 'unplugin-vue-components/vite'
 import {
   vueDsfrAutoimportPreset,
   vueDsfrComponentResolver
-} from '@gouvminint/vue-dsfr'
+} from '@gouvminint/vue-dsfr/meta'
 
 const isCypress = process.env.CYPRESS === 'true'
 


### PR DESCRIPTION
Bonjour,
S'agit-il d'un oubli ?

- Applique à pour-commencer.md la migration décrite dans migrations.md