### PR TITLE
fix: 🐛 lastTooltipShow est undefined

### DIFF
--- a/src/components/DsfrTooltip/DsfrTooltip.vue
+++ b/src/components/DsfrTooltip/DsfrTooltip.vue
@@ -101,7 +101,7 @@ const onMouseEnterHandler = (event: MouseEvent) => {
   if (props.onHover && (event.target === source.value || source.value?.contains(event.target as Node))) {
     show.value = true
     // @ts-ignore internal property available just for this component
-    globalThis.__vueDsfr__lastTooltipShow.value = false
+    globalThis.__vueDsfr__lastTooltipShow = false
   }
 }
 


### PR DESCRIPTION
Erreur vu dans le console : `Uncaught TypeError: globalThis.__vueDsfr__lastTooltipShow is undefined`

L'[autre utilisation](https://github.com/dnum-mi/vue-dsfr/blob/26193cdc0403709d23b94e23822a7eb26b624903/src/components/DsfrTooltip/DsfrTooltip.vue#L118) de `globalThis.__vueDsfr__lastTooltipShow` n'utilise pas `.value` alors je crois que c'est un bug.