### PR TITLE
fix: 🐛 ajoute la notion de rich sans icone pour les DsfrRadioButton

### DIFF
--- a/src/components/DsfrRadioButton/DsfrRadioButton.types.ts
+++ b/src/components/DsfrRadioButton/DsfrRadioButton.types.ts
@@ -8,6 +8,7 @@ export type DsfrRadioButtonProps = {
   value: string | number | boolean
   label?: string
   hint?: string
+  rich?: boolean
   img?: string
   imgTitle?: string
   svgPath?: string

--- a/src/components/DsfrRadioButton/DsfrRadioButton.vue
+++ b/src/components/DsfrRadioButton/DsfrRadioButton.vue
@@ -14,6 +14,7 @@ const props = withDefaults(defineProps<DsfrRadioButtonProps>(), {
   hint: '',
   img: undefined,
   svgPath: undefined,
+  rich: false,
   svgAttrs: () => ({ viewBox: '0 0 80 80', width: '80px', height: '80px' }),
 })
 
@@ -21,7 +22,7 @@ defineEmits<{ (e: 'update:modelValue', payload: string | number | boolean): void
 
 const defaultSvgAttrs = { viewBox: '0 0 80 80', width: '80px', height: '80px' }
 
-const rich = computed(() => !!props.img || !!props.svgPath)
+const richComputed = computed(() => props.rich || (!!props.img || !!props.svgPath))
 </script>
 
 <template>
@@ -32,7 +33,7 @@ const rich = computed(() => !!props.img || !!props.svgPath)
     <div
       class="fr-radio-group"
       :class="{
-        'fr-radio-rich': rich,
+        'fr-radio-rich': richComputed,
         'fr-radio-group--sm': small,
       }"
     >


### PR DESCRIPTION
[Conformément au DSFR](https://www.systeme-de-design.gouv.fr/composants-et-modeles/composants/bouton-radio-riche), on devrait avoir la possibilité d’avoir des boutons radios riches sans utiliser de pictos