### PR TITLE
Améliore le positionnement de l'infobulle (DsfrTooltip)

### DIFF
--- a/src/components/DsfrTooltip/DsfrTooltip.vue
+++ b/src/components/DsfrTooltip/DsfrTooltip.vue
@@ -70,9 +70,11 @@ watch(show, computePosition, { immediate: true })
 
 onMounted(() => {
   window.addEventListener('scroll', computePosition)
+  window.addEventListener('resize', computePosition)
 })
 onUnmounted (() => {
   window.removeEventListener('scroll', computePosition)
+  window.removeEventListener('resize', computePosition)
 })
 
 const tooltipStyle = computed(() => (`transform: translate(${translateX.value}, ${translateY.value}); --arrow-x: ${arrowX.value}; opacity: ${opacity.value};'`))

--- a/src/components/DsfrTooltip/DsfrTooltip.vue
+++ b/src/components/DsfrTooltip/DsfrTooltip.vue
@@ -26,6 +26,9 @@ async function computePosition () {
   if (typeof document === 'undefined') {
     return
   }
+  if (typeof window === 'undefined') {
+    return
+  }
   if (!show.value) {
     return
   }
@@ -40,7 +43,7 @@ async function computePosition () {
   const tooltipTop = tooltip.value?.offsetTop as number
   const tooltipLeft = tooltip.value?.offsetLeft as number
 
-  const isTooltipAtBottom = sourceTop + sourceHeight + tooltipHeight >= document.documentElement.offsetHeight
+  const isTooltipAtBottom = sourceTop + sourceHeight + tooltipHeight >= window.innerHeight
   top.value = isTooltipAtBottom
 
   const isTooltipOnRightSide = (sourceLeft + (sourceWidth / 2) + (tooltipWidth / 2)) >= document.documentElement.offsetWidth

--- a/src/components/DsfrTooltip/DsfrTooltip.vue
+++ b/src/components/DsfrTooltip/DsfrTooltip.vue
@@ -39,25 +39,26 @@ async function computePosition () {
   const tooltipWidth = tooltip.value?.offsetWidth as number
   const tooltipTop = tooltip.value?.offsetTop as number
   const tooltipLeft = tooltip.value?.offsetLeft as number
-  const isSourceAtTop = (sourceTop - tooltipHeight) < 0
-  const isSourceAtBottom = !isSourceAtTop && (sourceTop + sourceHeight + tooltipHeight) >= document.documentElement.offsetHeight
-  top.value = isSourceAtBottom
-  const isSourceOnRightSide = (sourceLeft + sourceWidth) >= document.documentElement.offsetWidth
-  const isSourceOnLeftSide = (sourceLeft + (sourceWidth / 2) - (tooltipWidth / 2)) <= 0
 
-  translateY.value = isSourceAtBottom
+  const isTooltipAtBottom = sourceTop + sourceHeight + tooltipHeight >= document.documentElement.offsetHeight
+  top.value = isTooltipAtBottom
+
+  const isTooltipOnRightSide = (sourceLeft + (sourceWidth / 2) + (tooltipWidth / 2)) >= document.documentElement.offsetWidth
+  const isTooltipOnLeftSide = (sourceLeft + (sourceWidth / 2) - (tooltipWidth / 2)) < 0
+
+  translateY.value = isTooltipAtBottom
     ? `${sourceTop - tooltipTop - tooltipHeight + 8}px`
     : `${sourceTop - tooltipTop + sourceHeight - 8}px`
   opacity.value = 1
-  translateX.value = isSourceOnRightSide
+  translateX.value = isTooltipOnRightSide
     ? `${sourceLeft - tooltipLeft + sourceWidth - tooltipWidth - 4}px`
-    : isSourceOnLeftSide
+    : isTooltipOnLeftSide
       ? `${sourceLeft - tooltipLeft + 4}px`
       : `${sourceLeft - tooltipLeft + (sourceWidth / 2) - (tooltipWidth / 2)}px`
 
-  arrowX.value = isSourceOnRightSide
+  arrowX.value = isTooltipOnRightSide
     ? `${(tooltipWidth / 2) - (sourceWidth / 2) + 4}px`
-    : isSourceOnLeftSide
+    : isTooltipOnLeftSide
       ? `${-(tooltipWidth / 2) + (sourceWidth / 2) - 4}px`
       : '0px'
 }


### PR DESCRIPTION
## 1. fix: :bug: Correction du chevauchement de l'infobulle sur le côté droit
Aujourd'hui, le positonnement dynamique de l'infobulle ne prend pas en compte la largeur de celle-ci par rapport au bord droit de la fenêtre, mais utilise la largeur du bouton qui permet de l'afficher. Le problème d'overlapping n'est donc pas visible si le bouton est collé à la bordure droite, mais le devient avec un écart plus conséquent :
<img width="688" alt="Capture d’écran 2025-05-13 à 17 22 41" src="https://github.com/user-attachments/assets/30e1bf48-a0b6-4644-9b61-2cb2a6f8e810" />

## 2. fix: 🐛  Correction du chevauchement de l'infobulle sur le côté inférieur
Aujourd'hui, le positionnement dynamique de l'infobulle ne prend pas en compte la hauteur de la fenêtre visible par l'utilisateur, mais la hauteur du document. Le problème d'overlapping n'est donc pas visible ci le document ne dépasse pas la fenêtre, mais le devient le cas échéant
<img width="487" alt="Capture d’écran 2025-05-13 à 18 07 47" src="https://github.com/user-attachments/assets/dbbb2a5e-d1d8-4e79-aee7-4102239edba8" />

## 2. feat: :sparkles: Re-calcule la position de l'infobulle au redimensionnement de la fenêtre
En cas de redimensionnement de la fenêtre, il faut recalculer la position souhaitée de l'infobulle, qui peut éventuellement sortir de la fenêtre.

Nous pourrions utiliser un `debouncer` pour limiter le nombre de calculs de positionnement (à la fois sur l'événement resize mais aussi sur celui de scroll, déjà écouté).
