### PR TITLE
DsfrHeader fixes sur les boutons Menu et recherche

### DIFF
--- a/src/components/DsfrHeader/DsfrHeader.vue
+++ b/src/components/DsfrHeader/DsfrHeader.vue
@@ -80,7 +80,7 @@ const showMenu = () => {
   // Sans le setTimeout, le focus n'est pas fait
   setTimeout(() => {
     document.getElementById('close-button')?.focus()
-  })
+  }, 50)
 }
 const showSearchModal = () => {
   modalOpened.value = true

--- a/src/components/DsfrHeader/DsfrHeader.vue
+++ b/src/components/DsfrHeader/DsfrHeader.vue
@@ -152,7 +152,11 @@ provide(registerNavigationLinkKey, () => {
                   :title="showSearchLabel"
                   :data-fr-opened="searchModalOpened"
                   @click.prevent.stop="showSearchModal()"
-                />
+                >
+                  <span class="fr-sr-only">
+                    {{ showSearchLabel }}
+                  </span>
+                </button>
                 <button
                   v-if="isWithSlotNav || quickLinks?.length"
                   id="button-menu"

--- a/src/components/DsfrHeader/DsfrHeader.vue
+++ b/src/components/DsfrHeader/DsfrHeader.vue
@@ -168,7 +168,11 @@ provide(registerNavigationLinkKey, () => {
                   :title="menuLabel"
                   data-testid="open-menu-btn"
                   @click.prevent.stop="showMenu()"
-                />
+                >
+                  <span class="fr-sr-only">
+                    {{ menuLabel }}
+                  </span>
+                </button>
               </div>
             </div>
             <div


### PR DESCRIPTION
- [🐛 ajoute le timing de focus du bouton fermer des quickLinks en mode mobile](https://github.com/dnum-mi/vue-dsfr/commit/ae4808247e51dae8d2b73f396917403bbc292702)

Bug trouvé lors d'un audit RGAA sur le bouton burger menu du DsfrHeader.
Lorsque l'on ouvre le menu des `quickLinks`, le focus reste sur le bouton d'ouverture et ne va pas sur le premier élément interactif de la modal.
 
Il existe bien un [forçage du focus dans le composant](https://github.com/dnum-mi/vue-dsfr/blob/main/src/components/DsfrHeader/DsfrHeader.vue#L81), mais sans [`delay`](https://developer.mozilla.org/fr/docs/Web/API/Window/setTimeout#delay) du `setTimeout`, il s'execute au bon cycle de changement la première fois mais pas aux suivantes.
Etant donné que l'affichage de la `nav` se fait via un rendu conditionné (`v-if`) et qu'il n'y a donc pas eu de précédent état, la création du noeud virtuel est immédiat, tandis que les fois suivantes, il y a déjà eu un noeud virtuel et Vue va faire une comparaison entre le nouveau et l'ancien noeud puis faire le rendu.
Ma théorie c'est que cette comparaison apporte un cycle en plus et créée une dissonance entre le `setTimeout` et Vue. Avec un `delay` temporel et non plus mécanique, le problème disparait.
On ne s'attend pas non plus à voir une délais élevé entre le click et l'ouverture, je pense qu'ajouter 50 ms suffit.
[Rendering Method](https://vuejs.org/guide/extras/rendering-mechanism)

Pour représenter le focus actif (`document.activeElement`), j'utilise cette règle CSS via [Stylus](https://addons.mozilla.org/fr/firefox/addon/styl-us/) :
```
body *:focus{outline:5px solid orange!important}
```

Sans `delay` :
![hehe](https://github.com/user-attachments/assets/8ef2aea8-dc23-40b9-a367-2135fb45d281)


Avec `delay` :
![hehe](https://github.com/user-attachments/assets/f7016189-fce9-4392-9215-52728251cb22)


- [fix (DsfrHeader): 🐛 ajoute un texte caché pour le bouton de recherche](https://github.com/dnum-mi/vue-dsfr/commit/67ec586ec420cdcbddae4b6480fede5fc04d94c9)

Autre bug RGAA, malgré la présence d'un `aria-label` et d'un `title`, cela ne suffit pas en termes d'accessibilité pour rendre le bouton explicite.
Si l'on désactive le style sur la page, alors le bouton apparait vide.
Cela fait référence au critère [RGAA 10.2](https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#10.2).

- [fix (DsfrHeader): 🐛 ajoute un texte caché pour le bouton de menu](https://github.com/dnum-mi/vue-dsfr/commit/21ffafbca58c91cc88fd73a7f32b6c63c293441e)

L'explication est identique au point précédent.
