### PR TITLE
Passer des props d'accessibilité aux inputs dans DsfrInputGroup

### DIFF
--- a/src/components/DsfrInput/DsfrInputGroup.vue
+++ b/src/components/DsfrInput/DsfrInputGroup.vue
@@ -38,7 +38,11 @@ defineEmits<{ (e: 'update:modelValue', payload: string): void }>()
   >
     <slot name="before-input" />
     <!-- @slot Slot par défaut pour le contenu du groupe de champ -->
-    <slot />
+    <slot
+      :is-valid="!!validMessage"
+      :is-invalid="!!errorMessage"
+      :description-id="((errorMessage || validMessage) && descriptionId) || undefined"  
+    />
     <DsfrInput
       v-if="!$slots.default"
       v-bind="$attrs"

--- a/src/components/DsfrInput/docs-demo/DsfrInputGroupDemo.vue
+++ b/src/components/DsfrInput/docs-demo/DsfrInputGroupDemo.vue
@@ -66,9 +66,11 @@ const readonly = ''
 
     <DsfrInputGroup
       valid-message="Tout va bien pour ces deux champs"
+      v-slot="slotProps"
     >
       <p>
         <DsfrInput
+          v-bind="slotProps"
           :id="id"
           :placeholder="placeholder"
           :readonly="readonly !== ''"
@@ -82,6 +84,7 @@ const readonly = ''
 
       <p>
         <DsfrInput
+          v-bind="slotProps"
           :id="id"
           :placeholder="placeholder"
           :readonly="readonly !== ''"


### PR DESCRIPTION
Cette PR vise à résoudre #1070 

Ça modifie `DsfrInputGroup` pour passer des props d'accessibilité dans le `slot`, et elle modifie l'exemple dans les docs pour utiliser ces props.