### PR TITLE
DsfrFooterLinkList Fixe sur la balise de titre

### DIFF
--- a/src/components/DsfrFooter/DsfrFooter.types.ts
+++ b/src/components/DsfrFooter/DsfrFooter.types.ts
@@ -30,7 +30,8 @@ export type DsfrFooterLinkProps = {
 
 export type DsfrFooterLinkListProps = {
   categoryName: string
-  links: DsfrFooterLinkProps[]
+  links: DsfrFooterLinkProps[],
+  titleTag: string,
 }
 
 export type DsfrFooterProps = {

--- a/src/components/DsfrFooter/DsfrFooterLinkList.md
+++ b/src/components/DsfrFooter/DsfrFooterLinkList.md
@@ -13,10 +13,11 @@ Le composant se compose de deux parties principales :
 
 ## 🛠️ Props
 
-| Nom de Prop | Type | Par défaut | Description |
-|-------------|------|------------|-------------|
-| `categoryName` | `string` | `'Nom de la catégorie'` | Le nom de la catégorie de liens affichée. |
-| `links` | `Array<DsfrFooterLinkProps>` | `[]` | Un tableau d'objets représentant les liens à afficher. Chaque objet peut avoir les propriétés de `DsfrFooterLinkProps`. |
+| Nom de Prop    | Type                         | Par défaut | Description                                                                                                           |
+|----------------|------------------------------|------------|-----------------------------------------------------------------------------------------------------------------------|
+| `categoryName` | `string`                     | `'Nom de la catégorie'` | Le nom de la catégorie de liens affichée.                                                                             |
+| `links`        | `Array<DsfrFooterLinkProps>` | `[]` | Un tableau d'objets représentant les liens à afficher. Chaque objet peut avoir les propriétés de `DsfrFooterLinkProps`. |
+| `titleTag`     | `string`                     | `'h3'` | Le type de balise pour afficher `categoryName`                                                 |                                                 |
 
 ## 📡Événements
 

--- a/src/components/DsfrFooter/DsfrFooterLinkList.vue
+++ b/src/components/DsfrFooter/DsfrFooterLinkList.vue
@@ -8,14 +8,18 @@ export type {
 withDefaults(defineProps<DsfrFooterLinkListProps>(), {
   categoryName: 'Nom de la catégorie',
   links: () => [],
+  titleTag: 'h3',
 })
 </script>
 
 <template>
   <div>
-    <h3 class="fr-footer__top-cat">
+    <component
+      class="fr-footer__top-cat"
+      :is="titleTag"
+    >
       {{ categoryName }}
-    </h3>
+    </component>
     <ul class="fr-footer__top-list">
       <li
         v-for="(link, idx) in links"


### PR DESCRIPTION
Bien le bonjour,


Petit retour d'audit RGAA, la balise de titre `DsfrFooterLinkList` remonte un KO dans la structuration des titres de la page.

Voici tous les titres de notre page, chaque couleur, excluant le `h1`, représente un bloc  + le `footer` :

![image](https://github.com/user-attachments/assets/5719c90c-66ca-4cb6-b127-5ca520c74f0a)

Visuellement, tous les titres sont bien ordonnées et hiérarchisés.

Le problème est que les technologies d'assistance remontent le `h3` du footer comme étant un titre enfant du `h2`. Cela nous génère une anomalie pour [le critère 9.1 du RGAA](https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#9.1).

La solution est de changer le type de titre `h3` du `DsfrFooterLinkList` par un `h2`.

TL;DR; rendre la balise de titre `categoryName` dynamique, avec une props ayant comme valeur par défaut `h3` permettant plus de souplesse pour les développements.
