### PR TITLE
Fix: DsfrPagination - corrige la désactivation des liens

### DIFF
--- a/src/components/DsfrPagination/DsfrPagination.vue
+++ b/src/components/DsfrPagination/DsfrPagination.vue
@@ -47,9 +47,10 @@ const isCurrentPage = (page: Page) => props.pages.indexOf(page) === props.curren
         <a
           :href="pages[0]?.href"
           class="fr-pagination__link fr-pagination__link--first"
+          :class="{ 'fr-pagination__link--disabled': currentPage === 0 }"
           :title="firstPageTitle"
           :aria-disabled="currentPage === 0 ? true : undefined"
-          @click.prevent="tofirstPage()"
+          @click.prevent="currentPage === 0 ? null : tofirstPage()"
         >
           <span class="fr-sr-only">{{ firstPageTitle }}</span>
         </a>
@@ -58,9 +59,10 @@ const isCurrentPage = (page: Page) => props.pages.indexOf(page) === props.curren
         <a
           :href="pages[Math.max(currentPage - 1, 0)]?.href"
           class="fr-pagination__link fr-pagination__link--prev fr-pagination__link--lg-label"
+          :class="{ 'fr-pagination__link--disabled': currentPage === 0 }"
           :title="prevPageTitle"
           :aria-disabled="currentPage === 0 ? true : undefined"
-          @click.prevent="toPreviousPage()"
+          @click.prevent="currentPage === 0 ? null : toPreviousPage()"
         >{{ prevPageTitle }}</a>
       </li>
       <li
@@ -83,20 +85,22 @@ const isCurrentPage = (page: Page) => props.pages.indexOf(page) === props.curren
         <a
           :href="pages[Math.min(currentPage + 1, pages.length - 1)]?.href"
           class="fr-pagination__link fr-pagination__link--next fr-pagination__link--lg-label"
+          :class="{ 'fr-pagination__link--disabled': currentPage === pages.length - 1 }"
           :title="nextPageTitle"
           :disabled="currentPage === pages.length - 1 ? true : undefined"
           :aria-disabled="currentPage === pages.length - 1 ? true : undefined"
-          @click.prevent="toNextPage()"
+          @click.prevent="currentPage === pages.length - 1 ? null : toNextPage()"
         >{{ nextPageTitle }}</a>
       </li>
       <li>
         <a
-          class="fr-pagination__link fr-pagination__link--last"
           :href="pages.at(-1)?.href"
+          class="fr-pagination__link fr-pagination__link--last"
+          :class="{ 'fr-pagination__link--disabled': currentPage === pages.length - 1 }"
           :title="lastPageTitle"
           :disabled="currentPage === pages.length - 1 ? true : undefined"
           :aria-disabled="currentPage === pages.length - 1 ? true : undefined"
-          @click.prevent="toLastPage()"
+          @click.prevent="currentPage === pages.length - 1 ? null : toLastPage()"
         >
           <span class="fr-sr-only">{{ lastPageTitle }}</span>
         </a>


### PR DESCRIPTION
Le composant DsfrPagination embarque une tentative d'implémentation de la [recommandation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/pagination) visant à désactiver les liens "Page précédente" et "Page suivante" lorsque l'utilisateur se trouve déjà respectivement, sur la première page ou la dernière page. 
Cette implémentation consiste à activer l'attribut "disabled" sur les liens. Or, l'attribut "disabled" n'est pas valide pour les éléments de type lien.
Cette correction propose, pour désactiver proprement les liens de pagination lorsqu'ils sont inactifs, d'utiliser une approche basée sur CSS:

1. Supprimer l'attribut :disabled des liens et conservez uniquement :aria-disabled pour l'accessibilité
2. Ajouter une classe conditionnelle pour les liens désactivés
3. Utiliser CSS pour styliser ces liens désactivés
4. Empêcher le clic sur les liens désactivés avec pointer-events: none
5. Ajouter une vérification conditionnelle dans le gestionnaire de clic pour plus de sécurité