### PR TITLE
Corrige l'affichage pour un DsfrInputGroup désactivé

### DIFF
--- a/docs/gabarit-doc-composant.md
+++ b/docs/gabarit-doc-composant.md
@@ -6,7 +6,7 @@ La tuile est un raccourci ou point d’entrée qui redirige les utilisateurs ver
 
 Le composant `DsfrTile` est une tuile flexible et stylisée, idéale pour afficher des informations sous forme de cartes visuelles dans une interface utilisateur. Ce composant permet d'intégrer des images, des SVG, des descriptions, des détails et des liens, tout en offrant de nombreuses options de personnalisation visuelle.
 
-🏅 La documentation sur la tuile sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/tuile/)
+🏅 La documentation sur la tuile sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/tuile/)
 
 <VIcon name="vi-file-type-storybook" /> La story sur la tuile sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrtile--docs)
 

--- a/docs/guide/icones-officielles.md
+++ b/docs/guide/icones-officielles.md
@@ -2,7 +2,7 @@
 
 Ci-dessous sont listées les icônes standards du DSFR disponibles directement via le CSS du DSFR.
 
-[Site officiel](https://www.systeme-de-design.gouv.fr/elements-d-interface/fondamentaux-techniques/icones)
+[Site officiel](https://www.systeme-de-design.gouv.fr/version-courante/fr/fondamentaux-techniques/icones)
 
 ## Les icônes par section
 

--- a/docs/guide/migrations.md
+++ b/docs/guide/migrations.md
@@ -210,7 +210,7 @@ Utiliser le minimum de CSS du DSFR :
 - les **styles des liens** du DSFR
 - les **classes utilitaires** du DSFR
 - le **CSS de VueDsfr**
-- éventuellement d’autres parties du CSS (notamment pour les icônes, cf. [la documentation officielle du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/fondamentaux-techniques/icones))
+- éventuellement d’autres parties du CSS (notamment pour les icônes, cf. [la documentation officielle du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/fondamentaux-techniques/icones))
 
 ```javascript
 import '@gouvfr/dsfr/dist/core/core.main.min.css' // Le CSS minimal du DSFR

--- a/src/components/DsfrAccordion/DsfrAccordion.md
+++ b/src/components/DsfrAccordion/DsfrAccordion.md
@@ -4,7 +4,7 @@
 
 Les accordéons permettent aux utilisateurs d'afficher et de masquer des sections de contenu présentés dans une page.
 
-🏅 La documentation sur l’accordéon sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/accordeon)
+🏅 La documentation sur l’accordéon sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/accordeon)
 
 <VIcon name="vi-file-type-storybook" /> La story sur l’accordéon sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfraccordion--docs)
 

--- a/src/components/DsfrAccordion/DsfrAccordion.stories.ts
+++ b/src/components/DsfrAccordion/DsfrAccordion.stories.ts
@@ -9,7 +9,7 @@ const delay = (timeout = 100) =>
   new Promise((resolve) => setTimeout(resolve, timeout))
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/accordeon/)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/accordeon/)
  */
 export default {
   component: DsfrAccordion,

--- a/src/components/DsfrAccordion/DsfrAccordionsGroup.md
+++ b/src/components/DsfrAccordion/DsfrAccordionsGroup.md
@@ -4,7 +4,7 @@
 
 Le composant `DsfrAccordionsGroup` permet de regrouper plusieurs accordéons en une seule unité cohérente. Il gère la logique de sélection active entre les accordéons enfants, permettant ainsi d'ouvrir un accordéon tout en fermant les autres. Ce composant est essentiel pour organiser des ensembles d'accordéons liés de manière interactive.
 
-🏅 La documentation sur l’accordéon sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/accordeon)
+🏅 La documentation sur l’accordéon sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/accordeon)
 
 <VIcon name="vi-file-type-storybook" /> La story sur l’accordéon sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfraccordionsgroup--docs)
 

--- a/src/components/DsfrAccordion/DsfrAccordionsGroup.stories.ts
+++ b/src/components/DsfrAccordion/DsfrAccordionsGroup.stories.ts
@@ -7,7 +7,7 @@ const delay = (timeout = 100) =>
   new Promise((resolve) => setTimeout(resolve, timeout))
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/accordeon/)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/accordeon/)
  */
 export default {
   component: DsfrAccordionsGroup,

--- a/src/components/DsfrAlert/DsfrAlert.md
+++ b/src/components/DsfrAlert/DsfrAlert.md
@@ -9,7 +9,7 @@ L’alerte est disponible en deux tailles :
 - taille médium (MD, par défaut, si la prop `small` est absente ou à `false`) et
 - petite taille ‘SM’ si la prop `small` est à `true`.
 
-🏅 La documentation sur l’alerte sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/alerte)
+🏅 La documentation sur l’alerte sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/alerte)
 
 <VIcon name="vi-file-type-storybook" /> La story sur l’alerte sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfralert--docs)
 

--- a/src/components/DsfrAlert/DsfrAlert.stories.ts
+++ b/src/components/DsfrAlert/DsfrAlert.stories.ts
@@ -6,7 +6,7 @@ const delay = (timeout = 100) =>
   new Promise((resolve) => setTimeout(resolve, timeout))
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/alerte)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/alerte)
  */
 export default {
   component: DsfrAlert,

--- a/src/components/DsfrBackToTop/DsfrBackToTop.md
+++ b/src/components/DsfrBackToTop/DsfrBackToTop.md
@@ -15,7 +15,7 @@ Le lien de retour en haut de page se place à la fin du contenu de la page, avan
 
 Si il y a des bloc de poursuite de lecture (liens vers d’autres articles), il est conseillé de placer le retour en haut de page avant ces blocs.
 
-🏅 La documentation sur le retour en haut de page sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/retour-en-haut-de-page/)
+🏅 La documentation sur le retour en haut de page sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/retour-en-haut-de-page/)
 
 <VIcon name="vi-file-type-storybook" /> La story sur le retour en haut de page sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrbacktotop--docs)
 

--- a/src/components/DsfrBackToTop/DsfrBackToTop.stories.ts
+++ b/src/components/DsfrBackToTop/DsfrBackToTop.stories.ts
@@ -1,7 +1,7 @@
 import DsfrBackToTop from './DsfrBackToTop.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/retour-en-haut-de-page/)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/retour-en-haut-de-page/)
  */
 export default {
   component: DsfrBackToTop,

--- a/src/components/DsfrBadge/DsfrBadge.md
+++ b/src/components/DsfrBadge/DsfrBadge.md
@@ -4,7 +4,7 @@
 
 Le `DsfrBadge` est le super-héros des petites étiquettes ! Ce composant Vue est idéal pour afficher des informations courtes et importantes, comme des catégories, des étiquettes ou des statuts. C'est comme le fromage sur votre pizza : petit mais essentiel !
 
-🏅 La documentation sur le badge sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/badge)
+🏅 La documentation sur le badge sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/badge)
 
 <VIcon name="vi-file-type-storybook" /> La story sur le badge sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrbadge--docs)
 

--- a/src/components/DsfrBadge/DsfrBadge.stories.ts
+++ b/src/components/DsfrBadge/DsfrBadge.stories.ts
@@ -1,7 +1,7 @@
 import DsfrBadge from './DsfrBadge.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/badge)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/badge)
  */
 export default {
   component: DsfrBadge,

--- a/src/components/DsfrBreadcrumb/DsfrBreadcrumb.md
+++ b/src/components/DsfrBreadcrumb/DsfrBreadcrumb.md
@@ -6,7 +6,7 @@ Bienvenue à la documentation du composant DsfrBreadcrumb ! Ce composant est un 
 
 Le fil d’Ariane est un système de navigation secondaire qui permet à l’utilisateur de se situer sur le site qu’il consulte.
 
-🏅 La documentation sur le fil d’Ariane sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/fil-d-ariane)
+🏅 La documentation sur le fil d’Ariane sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/fil-d-ariane)
 
 <VIcon name="vi-file-type-storybook" /> La story sur le fil d’Ariane sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrbreadcrumb--docs)
 

--- a/src/components/DsfrBreadcrumb/DsfrBreadcrumb.stories.ts
+++ b/src/components/DsfrBreadcrumb/DsfrBreadcrumb.stories.ts
@@ -4,7 +4,7 @@ import type { Meta, StoryFn } from '@storybook/vue3'
 import DsfrBreadcrumb from './DsfrBreadcrumb.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/fil-d-ariane)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/fil-d-ariane)
  */
 export default {
   component: DsfrBreadcrumb,

--- a/src/components/DsfrButton/DsfrButton.md
+++ b/src/components/DsfrButton/DsfrButton.md
@@ -6,7 +6,7 @@ Le bouton est un élément d’interaction avec l’interface permettant à l’
 
 Le `DsfrButton` est un composant Vue élégant et réutilisable, conçu pour simplifier la création de boutons personnalisés. Il intègre des tailles ajustables, des icônes optionnelles et un gestionnaire de clics, tout en respectant le style de `DSFR`. Son utilisation est simple, avec une grande flexibilité pour s'adapter à différents contextes.
 
-🏅 La documentation sur l’alerte sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/bouton)
+🏅 La documentation sur l’alerte sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/bouton)
 
 <VIcon name="vi-file-type-storybook" /> La story sur l’alerte sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrbutton--docs)
 

--- a/src/components/DsfrButton/DsfrButton.stories.ts
+++ b/src/components/DsfrButton/DsfrButton.stories.ts
@@ -5,7 +5,7 @@ import VIcon from '../VIcon/VIcon.vue'
 import DsfrButton from './DsfrButton.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/bouton)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/bouton)
  */
 export default {
   component: DsfrButton,

--- a/src/components/DsfrButton/DsfrButtonGroup.stories.ts
+++ b/src/components/DsfrButton/DsfrButtonGroup.stories.ts
@@ -5,7 +5,7 @@ import VIcon from '../VIcon/VIcon.vue'
 import DsfrButtonGroup from './DsfrButtonGroup.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/groupe-de-boutons)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/groupe-de-boutons)
  */
 export default {
   component: DsfrButtonGroup,

--- a/src/components/DsfrCallout/DsfrCallout.md
+++ b/src/components/DsfrCallout/DsfrCallout.md
@@ -2,7 +2,7 @@
 
 Le composant `DsfrCallout` est un composant Vue.js qui permet de créer des encadrés de mise en avant avec un titre, un contenu, une icône optionnelle, et un bouton configurable. Il est conçu pour s'intégrer harmonieusement dans les projets utilisant le Design System Français (DSFR), tout en offrant une grande flexibilité grâce à la personnalisation des éléments visuels.
 
-🏅 La documentation sur la mise en avant sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/mise-en-avant)
+🏅 La documentation sur la mise en avant sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/mise-en-avant)
 
 <VIcon name="vi-file-type-storybook" /> La story sur la mise en avant sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrcallout--docs)
 

--- a/src/components/DsfrCallout/DsfrCallout.stories.ts
+++ b/src/components/DsfrCallout/DsfrCallout.stories.ts
@@ -9,7 +9,7 @@ const delay = (timeout = 100) =>
   new Promise((resolve) => setTimeout(resolve, timeout))
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/mise-en-avant)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/mise-en-avant)
  */
 const meta: Meta<typeof DsfrCallout> = {
   component: DsfrCallout,

--- a/src/components/DsfrCard/DsfrCard.md
+++ b/src/components/DsfrCard/DsfrCard.md
@@ -6,7 +6,7 @@ La carte c'est tout simplement l'indispensable pour agrémenter vos sites et app
 
 La carte existe en trois tailles (LG, MD, SM) et deux formats (horizontal et vertical) déclinés sur deux supports (desktop et mobile), vous trouverez forcément votre bonheur ! Les cartes horizontales sont réservées au desktop (en mobile, une carte horizontale devient verticale).
 
-🏅 La documentation sur la carte sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/carte)
+🏅 La documentation sur la carte sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/carte)
 
 <VIcon name="vi-file-type-storybook" /> La story sur la carte sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrcard--docs)
 
@@ -58,8 +58,8 @@ Autres props :
 
 `start-details`  permet de placer une précision, sous forme de tags (cliquables ou non)
 
-cf. DSFR : [Composant - Tag](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/tag) ou [Composant - Badge](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/badge) (jusqu'à 4 éléments)
-cf. DSFR : [Composant - Carte](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/carte/).
+cf. DSFR : [Composant - Tag](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/tag) ou [Composant - Badge](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/badge) (jusqu'à 4 éléments)
+cf. DSFR : [Composant - Carte](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/carte/).
 
 ## 📝 Exemples
 

--- a/src/components/DsfrCard/DsfrCard.stories.ts
+++ b/src/components/DsfrCard/DsfrCard.stories.ts
@@ -5,7 +5,7 @@ import DsfrTags from './../DsfrTag/DsfrTags.vue'
 import DsfrCard from './DsfrCard.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/carte)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/carte)
  */
 export default {
   component: DsfrCard,

--- a/src/components/DsfrCard/docs-demo/DsfrCardDemo.vue
+++ b/src/components/DsfrCard/docs-demo/DsfrCardDemo.vue
@@ -9,7 +9,7 @@ import type { DsfrBadgeProps } from '../../DsfrBadge/DsfrBadge.types'
 const app = getCurrentInstance()
 app?.appContext.app.component('VICon', VICon)
 
-const link = 'https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/carte'
+const link = 'https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/carte'
 const description = 'Description exceptionnellement précise'
 const detail = 'Détails absolument essentiels'
 const detailIcon = 'Détails absolument essentiels'

--- a/src/components/DsfrCheckbox/DsfrCheckbox.md
+++ b/src/components/DsfrCheckbox/DsfrCheckbox.md
@@ -4,7 +4,7 @@ Les cases à cocher permettent à l’utilisateur de sélectionner une ou plusie
 
 La case à cocher peut être utilisée seule ou en liste. Évitez les listes de plus de 5 items et lorsque vous souhaitez contraindre le choix à un seul élément - utiliser [les boutons radios](/composants/DsfrRadioButton).
 
-🏅 La documentation sur **les cases à cocher** sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/case-a-cocher)
+🏅 La documentation sur **les cases à cocher** sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/case-a-cocher)
 
 <VIcon name="vi-file-type-storybook" /> La story sur **les cases à cocher** sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrcheckbox--docs)
 

--- a/src/components/DsfrCheckbox/DsfrCheckbox.stories.ts
+++ b/src/components/DsfrCheckbox/DsfrCheckbox.stories.ts
@@ -3,7 +3,7 @@ import { expect, fn, within } from '@storybook/test'
 import DsfrCheckbox from './DsfrCheckbox.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/case-a-cocher)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/case-a-cocher)
  */
 export default {
   component: DsfrCheckbox,

--- a/src/components/DsfrCheckbox/DsfrCheckboxSet.stories.ts
+++ b/src/components/DsfrCheckbox/DsfrCheckboxSet.stories.ts
@@ -3,7 +3,7 @@ import { expect, fn, within } from '@storybook/test'
 import DsfrCheckboxSet from './DsfrCheckboxSet.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/case-a-cocher)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/case-a-cocher)
  */
 export default {
   component: DsfrCheckboxSet,

--- a/src/components/DsfrConsent/DsfrConsent.md
+++ b/src/components/DsfrConsent/DsfrConsent.md
@@ -4,7 +4,7 @@
 
 Le gestionnaire de consentement permet à l'utilisateur de définir ses préférences sur l'utilisation de ses données personnelles, notamment le dépôt de cookies non fonctionnels dans son navigateur.
 
-🏅 La documentation du gestionnaire de consentement sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/gestionnaire-de-consentement)
+🏅 La documentation du gestionnaire de consentement sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/gestionnaire-de-consentement)
 
 <VIcon name="vi-file-type-storybook" /> La story du gestionnaire de consentement sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrconsent--docs)
 

--- a/src/components/DsfrConsent/DsfrConsent.stories.ts
+++ b/src/components/DsfrConsent/DsfrConsent.stories.ts
@@ -3,7 +3,7 @@ import { fn } from '@storybook/test'
 import DsfrConsent from './DsfrConsent.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/gestionnaire-de-consentement)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/gestionnaire-de-consentement)
  */
 export default {
   component: DsfrConsent,

--- a/src/components/DsfrDataTable/DsfrDataTable.md
+++ b/src/components/DsfrDataTable/DsfrDataTable.md
@@ -12,7 +12,7 @@ Si vous avez des propositions, veuillez lancer une [**discussion**](https://gith
 
 :::
 
-🏅 La documentation sur le tableau sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/tableau/)
+🏅 La documentation sur le tableau sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/tableau/)
 
 <VIcon name="vi-file-type-storybook" /> La story sur le tableau de données sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrdatatable--docs)
 

--- a/src/components/DsfrFileDownload/DsfrFileDownload.md
+++ b/src/components/DsfrFileDownload/DsfrFileDownload.md
@@ -4,7 +4,7 @@
 
 Le téléchargement de fichier permet à l'utilisateur de choisir un fichier à téléverser depuis son poste.
 
-🏅 La documentation du composant téléchargement de fichier sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/telechargement-de-fichier)
+🏅 La documentation du composant téléchargement de fichier sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/telechargement-de-fichier)
 
 <VIcon name="vi-file-type-storybook" /> La story du téléchargement de fichier sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrfiledownload--docs)
 

--- a/src/components/DsfrFileDownload/DsfrFileDownload.stories.ts
+++ b/src/components/DsfrFileDownload/DsfrFileDownload.stories.ts
@@ -1,7 +1,7 @@
 import DsfrFileDownload from './DsfrFileDownload.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/telechargement-de-fichier)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/telechargement-de-fichier)
  */
 export default {
   component: DsfrFileDownload,

--- a/src/components/DsfrFileDownload/DsfrFileDownloadList.stories.ts
+++ b/src/components/DsfrFileDownload/DsfrFileDownloadList.stories.ts
@@ -1,7 +1,7 @@
 import DsfrFileDownloadList from './DsfrFileDownloadList.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/telechargement-de-fichier)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/telechargement-de-fichier)
  */
 export default {
   component: DsfrFileDownloadList,

--- a/src/components/DsfrFileUpload/DsfrFileUpload.stories.ts
+++ b/src/components/DsfrFileUpload/DsfrFileUpload.stories.ts
@@ -1,7 +1,7 @@
 import DsfrFileUpload from './DsfrFileUpload.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/ajout-de-fichier)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/ajout-de-fichier)
  */
 export default {
   component: DsfrFileUpload,

--- a/src/components/DsfrFollow/DsfrFollow.stories.ts
+++ b/src/components/DsfrFollow/DsfrFollow.stories.ts
@@ -3,7 +3,7 @@ import { expect, within } from '@storybook/test'
 import DsfrFollow from './DsfrFollow.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/lettre-d-information-et-reseaux-sociaux)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/lettre-d-information-et-reseaux-sociaux)
  */
 export default {
   title: 'Composants/DsfrFollow',

--- a/src/components/DsfrFollow/DsfrNewsLetter.stories.ts
+++ b/src/components/DsfrFollow/DsfrNewsLetter.stories.ts
@@ -2,7 +2,7 @@ import DsfrFollow from './DsfrFollow.vue'
 import DsfrNewsLetter from './DsfrNewsLetter.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/lettre-d-information-et-reseaux-sociaux)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/lettre-d-information-et-reseaux-sociaux)
  */
 export default {
   component: DsfrNewsLetter,

--- a/src/components/DsfrFollow/DsfrSocialNetworks.stories.ts
+++ b/src/components/DsfrFollow/DsfrSocialNetworks.stories.ts
@@ -2,7 +2,7 @@ import DsfrFollow from './DsfrFollow.vue'
 import DsfrSocialNetworks from './DsfrSocialNetworks.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/lettre-d-information-et-reseaux-sociaux)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/lettre-d-information-et-reseaux-sociaux)
  */
 export default {
   title: 'Composants/DsfrSocialNetworks',

--- a/src/components/DsfrFooter/DsfrFooter.md
+++ b/src/components/DsfrFooter/DsfrFooter.md
@@ -6,7 +6,7 @@ Le `DsfrFooter` est un composant Vue.js pour créer un pied de page personnalis�
 
 Le pied de page est présent sur l’ensemble des pages du site. Il est situé en fin de page. Le trait bleu marque la séparation entre le corps de la page et le pied de page.
 
-🏅 La documentation sur le pied de page sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/pied-de-page)
+🏅 La documentation sur le pied de page sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/pied-de-page)
 
 <VIcon name="vi-file-type-storybook" /> La story sur le pied de page sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrfooter--docs)
 

--- a/src/components/DsfrFooter/DsfrFooter.stories.ts
+++ b/src/components/DsfrFooter/DsfrFooter.stories.ts
@@ -6,7 +6,7 @@ import DsfrFooter from './DsfrFooter.vue'
 import DsfrFooterLinkList from './DsfrFooterLinkList.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/pied-de-page)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/pied-de-page)
  */
 export default {
   component: DsfrFooter,

--- a/src/components/DsfrFooter/DsfrFooterLink.md
+++ b/src/components/DsfrFooter/DsfrFooterLink.md
@@ -4,7 +4,7 @@
 
 Le composant `DsfrFooterLink` de Vue.js permet de créer des liens personnalisés dans le pied de page. Ce composant versatile gère différents types de liens (boutons, liens internes, externes, e-mail) et peut être enrichi d'icônes.
 
-🏅 La documentation sur le pied de page sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/pied-de-page)
+🏅 La documentation sur le pied de page sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/pied-de-page)
 
 <VIcon name="vi-file-type-storybook" /> La story sur le pied de page sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrfooter--docs)
 

--- a/src/components/DsfrFranceConnect/DsfrFranceConnect.md
+++ b/src/components/DsfrFranceConnect/DsfrFranceConnect.md
@@ -10,7 +10,7 @@ Le fonctionnement en détail : <https://franceconnect.gouv.fr/partenaires>
 
 Le bouton FranceConnect est primordial dans l’usage du service FranceConnect. C’est par lui que passe la reconnaissance et la confiance dans la marque FranceConnect.
 
-🏅 La documentation sur le bouton FranceConnect sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/bouton-franceconnect)
+🏅 La documentation sur le bouton FranceConnect sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/bouton-franceconnect)
 
 <VIcon name="vi-file-type-storybook" /> La story sur le bouton FranceConnect sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrfranceconnect--docs)
 
@@ -57,7 +57,7 @@ Pas de slot.
 
 `DsfrFranceConnect` est conçu pour être simple et direct, permettant une intégration facile dans n'importe quelle application nécessitant une fonctionnalité de connexion FranceConnect.
 
-Il offre très peu de personnalisation, et cela est voulu (cf. les sections [« À ne pas faire » de la documentation officielle DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/bouton-franceconnect/)).
+Il offre très peu de personnalisation, et cela est voulu (cf. les sections [« À ne pas faire » de la documentation officielle DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/bouton-franceconnect/)).
 
 <script setup lang="ts">
 import DsfrFranceConnectDemo from './docs-demo/DsfrFranceConnectDemo.vue'

--- a/src/components/DsfrFranceConnect/DsfrFranceConnect.stories.ts
+++ b/src/components/DsfrFranceConnect/DsfrFranceConnect.stories.ts
@@ -1,7 +1,7 @@
 import DsfrFranceConnect from './DsfrFranceConnect.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/bouton-franceconnect)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/bouton-franceconnect)
  */
 export default {
   component: DsfrFranceConnect,

--- a/src/components/DsfrHeader/DsfrHeader.md
+++ b/src/components/DsfrHeader/DsfrHeader.md
@@ -4,7 +4,7 @@
 
 Salut les développeurs ! Découvrez `DsfrHeader`, le composant d'en-tête ultra-flexible pour vos applications Vue. Conçu pour mettre en valeur votre service et vos partenaires avec style, il intègre une barre de recherche, des liens rapides, et même un emplacement pour un logo personnalisé. Préparez-vous à donner à votre application une tête bien pensée !
 
-🏅 La documentation sur l’en-tête sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/en-tete)
+🏅 La documentation sur l’en-tête sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/en-tete)
 
 <VIcon name="vi-file-type-storybook" /> La story sur l’en-tête sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrheader--docs)
 

--- a/src/components/DsfrHeader/DsfrHeader.stories.ts
+++ b/src/components/DsfrHeader/DsfrHeader.stories.ts
@@ -9,7 +9,7 @@ const delay = (timeout = 100) =>
   new Promise((resolve) => setTimeout(resolve, timeout))
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/en-tete)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/en-tete)
  */
 export default {
   component: DsfrHeader,

--- a/src/components/DsfrHighlight/DsfrHighlight.md
+++ b/src/components/DsfrHighlight/DsfrHighlight.md
@@ -6,7 +6,7 @@ La mise en exergue permet à l’utilisateur de distinguer et repérer une infor
 
 Le composant `DsfrHighlight` est conçu pour mettre en exergue un texte ou un contenu particulier. Il permet d'afficher du texte avec des tailles personnalisables, en mettant l'accent sur l'importance du contenu. Ce composant est idéal pour attirer l'attention des utilisateurs sur des informations clés.
 
-🏅 La documentation sur le tag sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/tag)
+🏅 La documentation sur le tag sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/tag)
 
 <VIcon name="vi-file-type-storybook" /> La story sur le tag sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrtags--docs)
 

--- a/src/components/DsfrHighlight/DsfrHighlight.stories.ts
+++ b/src/components/DsfrHighlight/DsfrHighlight.stories.ts
@@ -3,7 +3,7 @@ import { expect, within } from '@storybook/test'
 import DsfrHighlight from './DsfrHighlight.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/mise-en-exergue)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/mise-en-exergue)
  */
 export default {
   component: DsfrHighlight,

--- a/src/components/DsfrInput/DsfrInput.md
+++ b/src/components/DsfrInput/DsfrInput.md
@@ -4,6 +4,10 @@
 
 Le composant `DsfrInput`, outil essentiel dans l'arsenal de tout développeur Vue ! Que ce soit pour saisir votre nom de fromage préféré ou la date de votre dernière visite à la Tour Eiffel, `DsfrInput` est là pour rendre la saisie de données aussi douce qu'un croissant frais le matin 🥐 (oui, on aime bien les croissants par ici).
 
+🏅 La documentation sur le champ de saisie sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/champ-de-saisie)
+
+<VIcon name="vi-file-type-storybook" /> La story sur le champ de saisie sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrinput--docs)
+
 ## 🛠️Props
 
 | Nom             | Type          | Défaut                  | Obligatoire   | Description                                                                                                 |

--- a/src/components/DsfrInput/DsfrInput.stories.ts
+++ b/src/components/DsfrInput/DsfrInput.stories.ts
@@ -8,7 +8,7 @@ import DsfrInput from './DsfrInput.vue'
 import DsfrInputGroup from './DsfrInputGroup.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/champ-de-saisie)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/champ-de-saisie)
  */
 export default {
   component: DsfrInput,

--- a/src/components/DsfrInput/DsfrInput.types.ts
+++ b/src/components/DsfrInput/DsfrInput.types.ts
@@ -14,6 +14,7 @@ export type DsfrInputProps = {
 }
 
 export type DsfrInputGroupProps = {
+  inputGroupId?: string
   descriptionId?: string
   hint?: string
   labelVisible?: boolean

--- a/src/components/DsfrInput/DsfrInputGroup.md
+++ b/src/components/DsfrInput/DsfrInputGroup.md
@@ -6,6 +6,10 @@ Bienvenue dans la documentation du composant `DsfrInputGroup`, conçu pour envel
 
 Ce composant est très utile si vous souhaitez afficher un message d’erreur ou de succès pour un ou plusieurs champs de saisie `DsfrInput`.
 
+🏅 La documentation sur le champ de saisie sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/champ-de-saisie)
+
+<VIcon name="vi-file-type-storybook" /> La story sur le champ de saisie sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrinputgroup--docs)
+
 ## 🛠️ Props
 
 | Nom             | Type        | Défaut                  | Obligatoire   | Description                                                   |

--- a/src/components/DsfrInput/DsfrInputGroup.spec.ts
+++ b/src/components/DsfrInput/DsfrInputGroup.spec.ts
@@ -3,6 +3,29 @@ import { render } from '@testing-library/vue'
 import DsfrInputGroup from './DsfrInputGroup.vue'
 
 describe('DsfrInputGroup', () => {
+  it('should disabled DsfrInputGroup', () => {
+    // Given
+    const descriptionId = 'my-id'
+    const inputGroupId = 'my-group-id'
+    const disabled = true
+
+    // When
+    const { getByTestId } = render(DsfrInputGroup, {
+      stubs: ['v-icon'],
+      props: {
+        descriptionId,
+        inputGroupId,
+        disabled,
+
+      },
+    })
+
+    // Then
+
+    expect(getByTestId(inputGroupId)).toHaveClass('fr-input-group--disabled')
+    expect(getByTestId(inputGroupId).querySelector('input')).toHaveProperty('disabled')
+  })
+
   it('should render DsfrInputGroup with error message', () => {
     // Given
     const errorMessage = 'my error message'

--- a/src/components/DsfrInput/DsfrInputGroup.stories.ts
+++ b/src/components/DsfrInput/DsfrInputGroup.stories.ts
@@ -2,7 +2,7 @@ import DsfrInput from './DsfrInput.vue'
 import DsfrInputGroup from './DsfrInputGroup.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/champ-de-saisie)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/champ-de-saisie)
  */
 export default {
   component: DsfrInputGroup,

--- a/src/components/DsfrInput/DsfrInputGroup.vue
+++ b/src/components/DsfrInput/DsfrInputGroup.vue
@@ -13,6 +13,7 @@ defineOptions({
 })
 
 const props = withDefaults(defineProps<DsfrInputGroupProps>(), {
+  inputGroupId: () => useRandomId('input-group', ''),
   descriptionId: () => useRandomId('input', 'group'),
   hint: '',
   label: '',
@@ -37,10 +38,10 @@ const descId = computed(() => {
     return getDescriptionIdFromArray(props.errorMessage, props.descriptionId)
   }
   if (typeof props.errorMessage === 'string') {
-    return props.errorMessage
+    return props.descriptionId
   }
   if (typeof props.validMessage === 'string') {
-    return props.validMessage
+    return props.descriptionId
   }
   if (Array.isArray(props.validMessage)) {
     return getDescriptionIdFromArray(props.validMessage, props.descriptionId)
@@ -54,11 +55,13 @@ const descId = computed(() => {
     class="fr-input-group"
     :class="[
       {
+        'fr-input-group--disabled': 'disabled' in $attrs,
         'fr-input-group--error': errorMessage,
         'fr-input-group--valid': (validMessage && !errorMessage),
       },
       wrapperClass,
     ]"
+    :data-testid="inputGroupId"
   >
     <slot name="before-input" />
     <!-- @slot Slot par défaut pour le contenu du groupe de champ -->

--- a/src/components/DsfrInput/docs-demo/DsfrInputGroupDemo.vue
+++ b/src/components/DsfrInput/docs-demo/DsfrInputGroupDemo.vue
@@ -13,16 +13,27 @@ const validMessage1 = 'Message de validation'
 const errorMessage1 = 'Message d’erreur'
 const errorMessage2 = 'Message d’erreur 2'
 const hint = 'Texte d’indice du champ'
-const id = ''
 const readonly = ''
 </script>
 
 <template>
   <div class="fr-container fr-my-2w">
-    <h2>1. Avec un message de succès</h2>
+    <h2>1. Désactivé</h2>
 
     <DsfrInputGroup
-      :id="id"
+      :placeholder="placeholder"
+      :readonly="readonly !== ''"
+      :model-value="modelValue"
+      :label="label"
+      :type="type"
+      :hint="hint"
+      label-visible
+      disabled
+    />
+
+    <h2>2. Avec un message de succès</h2>
+
+    <DsfrInputGroup
       :valid-message="validMessage1"
       :placeholder="placeholder"
       :readonly="readonly !== ''"
@@ -33,10 +44,9 @@ const readonly = ''
       label-visible
     />
 
-    <h2>2. Avec un message d’erreur</h2>
+    <h2>3. Avec un message d’erreur</h2>
 
     <DsfrInputGroup
-      :id="id"
       :error-message="errorMessage1"
       :placeholder="placeholder"
       :readonly="readonly !== ''"
@@ -47,10 +57,9 @@ const readonly = ''
       label-visible
     />
 
-    <h2>3. Avec plusieurs messages</h2>
+    <h2>4. Avec plusieurs messages</h2>
 
     <DsfrInputGroup
-      :id="id"
       :error-message="[errorMessage1, errorMessage2]"
       :valid-message="[validMessage1]"
       :placeholder="placeholder"
@@ -62,7 +71,7 @@ const readonly = ''
       label-visible
     />
 
-    <h2>4. Avec plusieurs champs de saisie</h2>
+    <h2>5. Avec plusieurs champs de saisie</h2>
 
     <DsfrInputGroup
       v-slot="slotProps"
@@ -71,7 +80,6 @@ const readonly = ''
       <p>
         <DsfrInput
           v-bind="slotProps"
-          :id="id"
           :placeholder="placeholder"
           :readonly="readonly !== ''"
           :model-value="modelValue"
@@ -84,7 +92,6 @@ const readonly = ''
 
       <p>
         <DsfrInput
-          :id="id"
           v-bind="slotProps"
           :placeholder="placeholder"
           :readonly="readonly !== ''"

--- a/src/components/DsfrLanguageSelector/DsfrLanguageSelector.md
+++ b/src/components/DsfrLanguageSelector/DsfrLanguageSelector.md
@@ -12,7 +12,7 @@ Ce composant est utilisé en interne dans [DsfrHeader](/composants/DsfrHeader) (
 
 :::
 
-🏅 La documentation sur le **sélecteur de langue** sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/selecteur-de-langue)
+🏅 La documentation sur le **sélecteur de langue** sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/selecteur-de-langue)
 
 <VIcon name="vi-file-type-storybook" /> La story sur le **sélecteur de langue** sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrlanguageselector--docs)
 

--- a/src/components/DsfrLanguageSelector/DsfrLanguageSelector.stories.ts
+++ b/src/components/DsfrLanguageSelector/DsfrLanguageSelector.stories.ts
@@ -1,7 +1,7 @@
 import DsfrLanguageSelector from './DsfrLanguageSelector.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/selecteur-de-langue)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/selecteur-de-langue)
  */
 export default {
   component: DsfrLanguageSelector,

--- a/src/components/DsfrMedia/DsfrPicture.md
+++ b/src/components/DsfrMedia/DsfrPicture.md
@@ -2,7 +2,7 @@
 
 Les contenus médias désignent vos contenus photos et vidéos. Lorsqu’ils sont intégrés à une page de contenu, il est recommandé de suivre les règles décrites ci-dessous.
 
-🏅 La documentation sur les contenus médias sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/contenus-medias)
+🏅 La documentation sur les contenus médias sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/contenus-medias)
 
 <VIcon name="vi-file-type-storybook" /> La story sur le contenu média image (picture) sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrpicture--docs)
 

--- a/src/components/DsfrMedia/DsfrVideo.md
+++ b/src/components/DsfrMedia/DsfrVideo.md
@@ -2,7 +2,7 @@
 
 Les contenus médias désignent vos contenus photos et vidéos. Lorsqu’ils sont intégrés à une page de contenu, il est recommandé de suivre les règles décrites ci-dessous.
 
-🏅 La documentation sur les contenus médias sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/contenus-medias)
+🏅 La documentation sur les contenus médias sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/contenus-medias)
 
 <VIcon name="vi-file-type-storybook" /> La story sur le contenus média video sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrvideo--docs)
 

--- a/src/components/DsfrModal/DsfrModal.md
+++ b/src/components/DsfrModal/DsfrModal.md
@@ -6,7 +6,7 @@ La modale permet de concentrer l’attention de l’utilisateur exclusivement su
 
 Le composant `DsfrModal` est une fenêtre modale configurable, offrant des fonctionnalités avancées telles que le piégeage de focus, l'écoute des touches d'échappement pour la fermeture, et la gestion des boutons d'action. Ce composant est conçu pour afficher des dialogues et des alertes de manière accessible et ergonomique.
 
-🏅 La documentation sur la modale sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/modale/)
+🏅 La documentation sur la modale sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/modale/)
 
 <VIcon name="vi-file-type-storybook" /> La story sur la modale sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrmodal--docs)
 

--- a/src/components/DsfrModal/DsfrModal.stories.ts
+++ b/src/components/DsfrModal/DsfrModal.stories.ts
@@ -14,7 +14,7 @@ setup((app) => {
 })
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/modale)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/modale)
  */
 export default {
   component: DsfrModal,

--- a/src/components/DsfrMultiselect/DsfrMultiSelect.stories.ts
+++ b/src/components/DsfrMultiselect/DsfrMultiSelect.stories.ts
@@ -3,7 +3,7 @@ import { fn } from '@storybook/test'
 import DsfrMultiSelect from './DsfrMultiselect.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/liste-deroulante)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/liste-deroulante)
  */
 export default {
   component: DsfrMultiSelect,

--- a/src/components/DsfrNavigation/DsfrNavigation.stories.ts
+++ b/src/components/DsfrNavigation/DsfrNavigation.stories.ts
@@ -1,7 +1,7 @@
 import DsfrNavigation from './DsfrNavigation.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/navigation-principale)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/navigation-principale)
  */
 export default {
   component: DsfrNavigation,

--- a/src/components/DsfrNotice/DsfrNotice.md
+++ b/src/components/DsfrNotice/DsfrNotice.md
@@ -6,7 +6,7 @@ Le bandeau d’information importante permet aux utilisateurs de voir ou d’acc
 
 Il est affiché sur l’ensemble des pages en desktop et en mobile. Il affiche une information importante et urgente (un usage trop fréquent risque de faire “disparaitre” ce bandeau).
 
-🏅 La documentation sur le bandeau d’information importante sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/bandeau-d-information-importante)
+🏅 La documentation sur le bandeau d’information importante sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/bandeau-d-information-importante)
 
 <VIcon name="vi-file-type-storybook" /> La story sur le bandeau d’information importante sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrnotice--docs)
 

--- a/src/components/DsfrNotice/DsfrNotice.stories.ts
+++ b/src/components/DsfrNotice/DsfrNotice.stories.ts
@@ -3,7 +3,7 @@ import { fn } from '@storybook/test'
 import DsfrNotice from './DsfrNotice.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/bandeau-d-information-importante)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/bandeau-d-information-importante)
  */
 export default {
   component: DsfrNotice,

--- a/src/components/DsfrPagination/DsfrPagination.md
+++ b/src/components/DsfrPagination/DsfrPagination.md
@@ -4,7 +4,7 @@
 
 Le composant `DsfrPagination` est un système de pagination conforme aux bonnes pratiques ergonomiques et accessible (ARIA). Il permet de naviguer facilement à travers plusieurs pages avec des fonctionnalités avancées comme la limitation de pages affichées et la gestion des événements.
 
-🏅 La documentation sur le pagination sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/pagination)
+🏅 La documentation sur le pagination sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/pagination)
 
 <VIcon name="vi-file-type-storybook" /> La story sur le tag sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrpagination--docs)
 

--- a/src/components/DsfrPagination/DsfrPagination.stories.ts
+++ b/src/components/DsfrPagination/DsfrPagination.stories.ts
@@ -3,7 +3,7 @@ import { expect, within } from '@storybook/test'
 import DsfrPagination from './DsfrPagination.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/pagination)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/pagination)
  */
 export default {
   component: DsfrPagination,

--- a/src/components/DsfrQuote/DsfrQuote.md
+++ b/src/components/DsfrQuote/DsfrQuote.md
@@ -4,7 +4,7 @@
 
 Le composant `DsfrQuote` permet d’afficher une citation stylisée, accompagnée d’un auteur, d’une source, et éventuellement d’une image illustrative. Ce composant respecte les standards du [Design System de l'État Français (DSFR)](https://www.systeme-de-design.gouv.fr/) pour offrir une présentation élégante et accessible.
 
-🏅 La documentation sur les liens d’évitement le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/citation)
+🏅 La documentation sur les liens d’évitement le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/citation)
 
 <VIcon name="vi-file-type-storybook" /> La story sur les liens d’évitement sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrquote--docs)
 

--- a/src/components/DsfrQuote/DsfrQuote.stories.ts
+++ b/src/components/DsfrQuote/DsfrQuote.stories.ts
@@ -1,7 +1,7 @@
 import DsfrQuote from './DsfrQuote.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/citation)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/citation)
  */
 export default {
   component: DsfrQuote,

--- a/src/components/DsfrRadioButton/DsfrRadioButton.md
+++ b/src/components/DsfrRadioButton/DsfrRadioButton.md
@@ -14,9 +14,9 @@ Le bouton radio ne peut pas être utilisé seul : il faut au minimum 2 options. 
 
 Les boutons radio riches permettent de sélectionner un choix parmi une liste d’options illustrées. À la différence du bouton radio simple, l’image permet d’illustrer et d’accompagner l’utilisateur dans son choix.
 
-Concernant les images, elles peuvent être des artworks/pictogrammes au format SVG. Il faut alors se référer [aux fondamentaux techniques du DSFR pour la définition des SVG](https://www.systeme-de-design.gouv.fr/elements-d-interface/fondamentaux-techniques/pictogramme).
+Concernant les images, elles peuvent être des artworks/pictogrammes au format SVG. Il faut alors se référer [aux fondamentaux techniques du DSFR pour la définition des SVG](https://www.systeme-de-design.gouv.fr/version-courante/fr/fondamentaux-techniques/pictogramme).
 
-🏅 La documentation sur le [bouton radio](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/bouton-radio) et le [bouton radio riche](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/bouton-radio-riche) sur le DSFR
+🏅 La documentation sur le [bouton radio](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/bouton-radio) et le [bouton radio riche](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/bouton-radio-riche) sur le DSFR
 
 <VIcon name="vi-file-type-storybook" /> La story sur le bouton radio sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrradiobutton--docs)
 

--- a/src/components/DsfrRadioButton/DsfrRadioButton.stories.ts
+++ b/src/components/DsfrRadioButton/DsfrRadioButton.stories.ts
@@ -4,7 +4,7 @@ import DsfrRadioButton from './DsfrRadioButton.vue'
 import DsfrRadioButtonSet from './DsfrRadioButtonSet.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/boutons-radio)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/boutons-radio)
  *
  * Nous vous invitons à regarder plutôt la [nouvelle documentation](https://vue-ds.fr/composants/DsfrRadioButton) pour ce composant
  */

--- a/src/components/DsfrRadioButton/DsfrRadioButtonSet.md
+++ b/src/components/DsfrRadioButton/DsfrRadioButtonSet.md
@@ -4,7 +4,7 @@
 
 Les groupes de boutons radio (riches) permettent d’éviter d’écrire plusieurs fois le composant [`DsfrRadioButton`](./DsfrRadioButton), il est fortement conseillé de l’utiliser plutôt que de répéter `DsfrRadioButton`.
 
-🏅 La documentation sur le [bouton radio](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/bouton-radio) et le [bouton radio riche](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/bouton-radio-riche) sur le DSFR
+🏅 La documentation sur le [bouton radio](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/bouton-radio) et le [bouton radio riche](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/bouton-radio-riche) sur le DSFR
 
 <VIcon name="vi-file-type-storybook" /> La story sur le groupe de boutons radio sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrradiobuttonset--docs)
 

--- a/src/components/DsfrRadioButton/DsfrRadioButtonSet.stories.ts
+++ b/src/components/DsfrRadioButton/DsfrRadioButtonSet.stories.ts
@@ -3,7 +3,7 @@ import { expect, fn, within } from '@storybook/test'
 import DsfrRadioButtonSet from './DsfrRadioButtonSet.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/boutons-radio)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/boutons-radio)
  */
 export default {
   component: DsfrRadioButtonSet,

--- a/src/components/DsfrRange/DsfrRange.md
+++ b/src/components/DsfrRange/DsfrRange.md
@@ -6,7 +6,7 @@ Bienvenue dans la documentation du `DsfrRange`, un composant Vue qui va slider d
 
 Les curseurs sont des entrées numériques qui permettent de voir graphiquement une sélection par rapport a une valeur minimale et maximale. Ils servent à montrer en temps réel les options choisies et éclairer la prise de décision. ("Why so serious?" 🦇🃏)
 
-🏅 La documentation sur le curseur importante sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/bandeau-d-information-importante)
+🏅 La documentation sur le curseur importante sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/bandeau-d-information-importante)
 
 <VIcon name="vi-file-type-storybook" /> La story sur le curseur importante sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrnotice--docs)
 

--- a/src/components/DsfrSearchBar/DsfrSearchBar.md
+++ b/src/components/DsfrSearchBar/DsfrSearchBar.md
@@ -4,7 +4,7 @@
 
 La barre de recherche est un système de navigation qui permet à l'utilisateur d’accéder rapidement à un contenu en lançant une recherche sur un mot clé ou une expression.
 
-🏅 La documentation sur la barre de recherche sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/barre-de-recherche)
+🏅 La documentation sur la barre de recherche sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/barre-de-recherche)
 
 <VIcon name="vi-file-type-storybook" /> La story sur la barre de recherche sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrsearchbar--docs)
 

--- a/src/components/DsfrSearchBar/DsfrSearchBar.stories.ts
+++ b/src/components/DsfrSearchBar/DsfrSearchBar.stories.ts
@@ -1,7 +1,7 @@
 import DsfrSearchBar from './DsfrSearchBar.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/barre-de-recherche)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/barre-de-recherche)
  */
 export default {
   component: DsfrSearchBar,

--- a/src/components/DsfrSegmented/DsfrSegmented.md
+++ b/src/components/DsfrSegmented/DsfrSegmented.md
@@ -6,7 +6,7 @@
 
 Le composant « contrôle segmenté » incite l'utilisateur à choisir entre plusieurs options d'affichage disponibles (vues), mutuellement exclusives avec une valeur sélectionnée par défaut (oui, ça c’est la version sérieuse de l’introduction à ce composant).
 
-🏅 La documentation sur les boutons segmentés sur le [DSFR sera ici](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/controle-segmente) (n’existe pas encore à l’heure où cette documentation est écrite, on est dans l’turfu, nous, qu’on vous dit !).
+🏅 La documentation sur les boutons segmentés sur le [DSFR sera ici](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/controle-segmente) (n’existe pas encore à l’heure où cette documentation est écrite, on est dans l’turfu, nous, qu’on vous dit !).
 
 <VIcon name="vi-file-type-storybook" /> La story sur l’alerte sur le storybook de [VueDsfr est ici](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrsegmented--docs) (merci [Vincent Lainé](https://github.com/vincentlaine/) !).
 

--- a/src/components/DsfrSegmented/DsfrSegmented.stories.ts
+++ b/src/components/DsfrSegmented/DsfrSegmented.stories.ts
@@ -3,7 +3,7 @@ import { fn } from '@storybook/test'
 import DsfrSegmented from './DsfrSegmented.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/controle-segmente)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/controle-segmente)
  */
 export default {
   component: DsfrSegmented,

--- a/src/components/DsfrSegmented/DsfrSegmentedSet.md
+++ b/src/components/DsfrSegmented/DsfrSegmentedSet.md
@@ -4,7 +4,7 @@
 
 Le composant « contrôle segmenté » incite l'utilisateur à choisir entre plusieurs options d'affichage disponibles (vues), mutuellement exclusives avec une valeur sélectionnée par défaut (Il faut toujours ramener un peu de sérieux dans l’affaire...).
 
-🏅 La documentation sur les boutons segmentés sur le [DSFR sera ici](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/controle-segmente) (n’existe pas non plus à l’heure où cette documentation est écrite, on est trop en avance, nous !).
+🏅 La documentation sur les boutons segmentés sur le [DSFR sera ici](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/controle-segmente) (n’existe pas non plus à l’heure où cette documentation est écrite, on est trop en avance, nous !).
 
 <VIcon name="vi-file-type-storybook" /> La story sur l’alerte sur le storybook de [VueDsfr est ici](https://vue-ds.fr/?path=/docs/composants-dsfrsegmentedset--docs) (oui parce que nous on fait rien à moitié, nous 😏, merci [Vincent Lainé](https://github.com/vincentlaine/) !).
 

--- a/src/components/DsfrSegmented/DsfrSegmentedSet.stories.ts
+++ b/src/components/DsfrSegmented/DsfrSegmentedSet.stories.ts
@@ -3,7 +3,7 @@ import { fn } from '@storybook/test'
 import DsfrSegmentedSet from './DsfrSegmentedSet.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/controle-segmente)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/controle-segmente)
  */
 export default {
   component: DsfrSegmentedSet,

--- a/src/components/DsfrSelect/DsfrSelect.stories.ts
+++ b/src/components/DsfrSelect/DsfrSelect.stories.ts
@@ -3,7 +3,7 @@ import { fn } from '@storybook/test'
 import DsfrSelect from './DsfrSelect.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/liste-deroulante)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/liste-deroulante)
  */
 export default {
   component: DsfrSelect,

--- a/src/components/DsfrShare/DsfrShare.md
+++ b/src/components/DsfrShare/DsfrShare.md
@@ -4,7 +4,7 @@
 
 Le composant `DsfrShare` permet d’ajouter une fonctionnalité de partage sur une page, en respectant les standards du [Design System de l'État Français (DSFR)](https://www.systeme-de-design.gouv.fr/). Il propose des boutons configurables pour partager via des réseaux sociaux, par email ou en copiant le lien dans le presse-papier.
 
-🏅 La documentation sur le partage le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/partage)
+🏅 La documentation sur le partage le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/partage)
 
 <VIcon name="vi-file-type-storybook" /> La story sur le partage sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrshare--docs)
 

--- a/src/components/DsfrShare/DsfrShare.stories.ts
+++ b/src/components/DsfrShare/DsfrShare.stories.ts
@@ -1,7 +1,7 @@
 import DsfrShare from './DsfrShare.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/partage)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/partage)
  */
 export default {
   component: DsfrShare,

--- a/src/components/DsfrSideMenu/DsfrSideMenu.stories.ts
+++ b/src/components/DsfrSideMenu/DsfrSideMenu.stories.ts
@@ -19,7 +19,7 @@ function toggleExpandedForMenuWithId (menuItems, id) {
 }
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/menu-lateral)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/menu-lateral)
  */
 export default {
   component: DsfrSideMenu,

--- a/src/components/DsfrSkipLinks/DsfrSkipLinks.md
+++ b/src/components/DsfrSkipLinks/DsfrSkipLinks.md
@@ -4,7 +4,7 @@
 
 Le composant `DsfrSkipLinks` fournit des liens d'accès rapide, permettant aux utilisateurs de naviguer directement vers des sections clés de la page. Ce composant est particulièrement utile pour améliorer l'accessibilité, notamment pour les utilisateurs de lecteurs d'écran ou de navigation clavier, en respectant les standards du [Design System de l'État Français (DSFR)](https://www.systeme-de-design.gouv.fr/).
 
-🏅 La documentation sur les liens d’évitement le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/lien-d-evitement)
+🏅 La documentation sur les liens d’évitement le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/lien-d-evitement)
 
 <VIcon name="vi-file-type-storybook" /> La story sur les liens d’évitement sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrskiplinks--docs)
 

--- a/src/components/DsfrSkipLinks/DsfrSkipLinks.stories.ts
+++ b/src/components/DsfrSkipLinks/DsfrSkipLinks.stories.ts
@@ -3,7 +3,7 @@ import { expect, userEvent, within } from '@storybook/test'
 import DsfrSkipLinks from './DsfrSkipLinks.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/lien-d-evitement)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/lien-d-evitement)
  */
 export default {
   component: DsfrSkipLinks,

--- a/src/components/DsfrStepper/DsfrStepper.stories.ts
+++ b/src/components/DsfrStepper/DsfrStepper.stories.ts
@@ -1,7 +1,7 @@
 import DsfrStepper from './DsfrStepper.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/indicateur-d-etape)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/indicateur-d-etape)
  */
 export default {
   component: DsfrStepper,

--- a/src/components/DsfrSummary/DsfrSummary.md
+++ b/src/components/DsfrSummary/DsfrSummary.md
@@ -4,7 +4,7 @@
 
 Le composant `DsfrSummary` est conçu pour afficher un sommaire accessible et stylisé selon les standards du [Design System de l'État Français (DSFR)](https://www.systeme-de-design.gouv.fr/). Il est idéal pour améliorer la navigation dans une page en proposant des liens vers les différentes sections.
 
-🏅 La documentation sur le tag sommaire le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/sommaire)
+🏅 La documentation sur le tag sommaire le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/sommaire)
 
 <VIcon name="vi-file-type-storybook" /> La story sur le sommaire sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrsummary--docs)
 

--- a/src/components/DsfrSummary/DsfrSummary.stories.ts
+++ b/src/components/DsfrSummary/DsfrSummary.stories.ts
@@ -1,7 +1,7 @@
 import DsfrSummary from './DsfrSummary.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/sommaire)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/sommaire)
  */
 export default {
   component: DsfrSummary,

--- a/src/components/DsfrTable/DsfrTable.md
+++ b/src/components/DsfrTable/DsfrTable.md
@@ -4,7 +4,7 @@
 
 Le composant `DsfrTable` est un élément puissant et polyvalent pour afficher des données sous forme de tableaux dans vos applications Vue. Utilisant une combinaison de slots, de props, et d'événements personnalisés, ce composant offre une flexibilité remarquable. Plongeons dans les détails !
 
-🏅 La documentation sur le tableau sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/tableau/)
+🏅 La documentation sur le tableau sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/tableau/)
 
 <VIcon name="vi-file-type-storybook" /> La story sur le tableau sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrtable--docs)
 

--- a/src/components/DsfrTable/DsfrTable.stories.ts
+++ b/src/components/DsfrTable/DsfrTable.stories.ts
@@ -12,7 +12,7 @@ setup((app) => {
 })
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/tableau)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/tableau)
  */
 export default {
   component: DsfrTable,

--- a/src/components/DsfrTable/DsfrTableCell.md
+++ b/src/components/DsfrTable/DsfrTableCell.md
@@ -4,7 +4,7 @@
 
 `DsfrTableCell`, c'est la cellule magique de vos tableaux Vue ! Ce composant flexible gère l'affichage de chaque cellule, avec la possibilité d'inclure du texte, des composants personnalisés, et plus encore. Découvrons ensemble comment l'utiliser au mieux.
 
-🏅 La documentation sur le tableau sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/tableau)
+🏅 La documentation sur le tableau sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/tableau)
 
 <VIcon name="vi-file-type-storybook" /> La story sur la cellule de tableau sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrtablerow--docs)
 

--- a/src/components/DsfrTable/DsfrTableHeader.md
+++ b/src/components/DsfrTable/DsfrTableHeader.md
@@ -4,7 +4,7 @@ Enfant de `DsfrHeaders` (attention au pluriel), `DsfrHeader` (ici donc au singul
 
 Parfait pour ajouter du texte et des icônes personnalisées, ce composant est un incontournable pour un tableau élégant et fonctionnel.
 
-🏅 La documentation sur le tableau sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/tableau/)
+🏅 La documentation sur le tableau sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/tableau/)
 
 <VIcon name="vi-file-type-storybook" /> La story sur l’en-tête de tableau sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrtableheader--docs)
 

--- a/src/components/DsfrTable/DsfrTableHeaders.md
+++ b/src/components/DsfrTable/DsfrTableHeaders.md
@@ -4,7 +4,7 @@
 
 Bienvenue dans la documentation du composant `DsfrTableHeaders`! Ce composant est comme le maestro d'un orchestre, orchestrant l'affichage des en-têtes de vos tableaux Vue avec élégance et précision. Allons-y pour découvrir ses caractéristiques.
 
-🏅 La documentation sur le tableau sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/tableau/)
+🏅 La documentation sur le tableau sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/tableau/)
 
 <VIcon name="vi-file-type-storybook" /> La story sur les en-têtes de tableau sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrtableheaders--docs)
 

--- a/src/components/DsfrTabs/DsfrTabs.md
+++ b/src/components/DsfrTabs/DsfrTabs.md
@@ -6,7 +6,7 @@ Le composant onglet permet aux utilisateurs de naviguer dans différentes sectio
 
 Le système d'onglet aide à regrouper différents contenus dans un espace limité et permet de diviser un contenu dense en sections accessibles individuellement afin de faciliter la lecture pour l'utilisateur.
 
-🏅 La documentation sur les onglets sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/onglet/)
+🏅 La documentation sur les onglets sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/onglet/)
 
 <VIcon name="vi-file-type-storybook" /> La story sur les onglets sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrtabs--docs)
 

--- a/src/components/DsfrTabs/DsfrTabs.stories.ts
+++ b/src/components/DsfrTabs/DsfrTabs.stories.ts
@@ -26,7 +26,7 @@ const tabContents = [
 ]
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/onglet)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/onglet)
  */
 const meta = {
   component: DsfrTabs,

--- a/src/components/DsfrTag/DsfrTag.md
+++ b/src/components/DsfrTag/DsfrTag.md
@@ -13,7 +13,7 @@ Le tag peut être utilisé dans deux contextes :
   - activable comme filtre en place à sélectionner/désélectionner ;
   - supprimable, il sert de rappel à un filtre qui a été coché dans une sidebar ou une liste déroulante.
 
-🏅 La documentation sur le tag sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/tag)
+🏅 La documentation sur le tag sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/tag)
 
 <VIcon name="vi-file-type-storybook" /> La story sur le tag sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrtags--docs)
 

--- a/src/components/DsfrTag/DsfrTags.md
+++ b/src/components/DsfrTag/DsfrTags.md
@@ -4,7 +4,7 @@
 
 Le composant `DsfrTags` permet d'afficher un groupe de tags interactifs et personnalisables. Il est particulièrement utile pour gérer des listes de filtres ou des catégories sélectionnables. Il s'appuie sur le composant [`DsfrTag`](./DsfrTag.md) et offre la possibilité de suivre l'état des tags sélectionnés via une liaison avec `v-model`.
 
-🏅 La documentation sur le tag sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/tag)
+🏅 La documentation sur le tag sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/tag)
 
 <VIcon name="vi-file-type-storybook" /> La story sur le tag sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrtags--docs)
 

--- a/src/components/DsfrTag/DsfrTags.stories.ts
+++ b/src/components/DsfrTag/DsfrTags.stories.ts
@@ -2,7 +2,7 @@ import DsfrTag from './DsfrTag.vue'
 import DsfrTags from './DsfrTags.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/tag)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/tag)
  */
 export default {
   component: DsfrTags,

--- a/src/components/DsfrTile/DsfrTile.md
+++ b/src/components/DsfrTile/DsfrTile.md
@@ -6,7 +6,7 @@ La tuile est un raccourci ou point d’entrée qui redirige les utilisateurs ver
 
 Le composant `DsfrTile` est une tuile flexible et stylisée, idéale pour afficher des informations sous forme de cartes visuelles dans une interface utilisateur. Ce composant permet d'intégrer des images, des SVG, des descriptions, des détails et des liens, tout en offrant de nombreuses options de personnalisation visuelle.
 
-🏅 La documentation sur la tuile sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/tuile)
+🏅 La documentation sur la tuile sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/tuile)
 
 <VIcon name="vi-file-type-storybook" /> La story sur la tuile sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrtile--docs)
 

--- a/src/components/DsfrTile/DsfrTile.stories.ts
+++ b/src/components/DsfrTile/DsfrTile.stories.ts
@@ -1,7 +1,7 @@
 import DsfrTile from './DsfrTile.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/tuile)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/tuile)
  *
  * Nous vous invitons à regarder plutôt la [nouvelle documentation](https://vue-ds.fr/composants/DsfrTile) pour ce composant
  */

--- a/src/components/DsfrTile/DsfrTiles.md
+++ b/src/components/DsfrTile/DsfrTiles.md
@@ -6,7 +6,7 @@ Le composant `DsfrTiles` utilise le composant .
 
 Le composant `DsfrTiles` permet d'afficher une collection de tuiles ([`DsfrTile`](/composants/DsfrTile)) de manière organisée dans une grille. Il offre la possibilité de personnaliser la disposition de chaque tuile, de les afficher en mode horizontal ou vertical, et d'appliquer des classes spécifiques pour un style personnalisé. Ce composant est idéal pour créer des galeries ou des listes d'éléments visuels interactifs.
 
-🏅 La documentation sur la tuile sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/tuile)
+🏅 La documentation sur la tuile sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/tuile)
 
 <VIcon name="vi-file-type-storybook" /> La story sur la tuile sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrtiles--docs)
 

--- a/src/components/DsfrTile/DsfrTiles.stories.ts
+++ b/src/components/DsfrTile/DsfrTiles.stories.ts
@@ -1,7 +1,7 @@
 import DsfrTiles from './DsfrTiles.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/tuile)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/tuile)
  */
 export default {
   component: DsfrTiles,

--- a/src/components/DsfrToggleSwitch/DsfrToggleSwitch.stories.ts
+++ b/src/components/DsfrToggleSwitch/DsfrToggleSwitch.stories.ts
@@ -3,7 +3,7 @@ import { expect, fn, within } from '@storybook/test'
 import DsfrToggleSwitch from './DsfrToggleSwitch.vue'
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/interrupteur)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/interrupteur)
  */
 export default {
   component: DsfrToggleSwitch,

--- a/src/components/DsfrTranscription/DsfrTranscription.md
+++ b/src/components/DsfrTranscription/DsfrTranscription.md
@@ -1,6 +1,6 @@
 # Transcription - `DsfrTranscription`
 
-🏅 La documentation sur la transcription sur le [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/transcription)
+🏅 La documentation sur la transcription sur le [DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/transcription)
 
 <VIcon name="vi-file-type-storybook" /> La story sur la transcription sur le storybook de [VueDsfr](https://storybook.vue-ds.fr/?path=/docs/composants-dsfrtranscription--docs)
 

--- a/src/components/DsfrTranscription/DsfrTranscription.stories.ts
+++ b/src/components/DsfrTranscription/DsfrTranscription.stories.ts
@@ -11,7 +11,7 @@ setup((app) => {
 })
 
 /**
- * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/transcription)
+ * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/transcription)
  */
 export default {
   component: DsfrTranscription,

--- a/src/stories/docs/04-migration.mdx
+++ b/src/stories/docs/04-migration.mdx
@@ -60,7 +60,7 @@ Utiliser le minimum de CSS du DSFR :
 * les **styles des liens** du DSFR
 * les **classes utilitaires** du DSFR
 * le **CSS de VueDsfr**
-* éventuellement d’autres parties du CSS (notamment pour les icônes, cf. [la documentation officielle du DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/fondamentaux-techniques/icones))
+* éventuellement d’autres parties du CSS (notamment pour les icônes, cf. [la documentation officielle du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/fondamentaux-techniques/icones))
 
 ```javascript
 import '@gouvfr/dsfr/dist/core/core.main.min.css'            // Le CSS minimal du DSFR

--- a/src/stories/fondamentaux/icones-officielles.mdx
+++ b/src/stories/fondamentaux/icones-officielles.mdx
@@ -6,7 +6,7 @@ import { Meta } from '@storybook/blocks'
 
 Ci-dessous sont listées les icônes standards du DSFR disponibles directement via le CSS du DSFR.
 
-[Site officiel](https://www.systeme-de-design.gouv.fr/elements-d-interface/fondamentaux-techniques/icones)
+[Site officiel](https://www.systeme-de-design.gouv.fr/version-courante/fr/fondamentaux-techniques/icones)
 
 ## Buildings
 


### PR DESCRIPTION
fix #1114 

- correction des liens vers la doc dsfr

- correction de l'affichage pour un DsfrInputGroup désactivé
  - ajout de la classe fr-input-group--disabled  si disabled
  - correction id input
  - test DsfrInputGroup désactivé
  - modification démo (affichage de id input et label for)
  - correction aria-describedby pour les messages d'erreur ou de validation unique (afficher le contenu lui même correspond à aria-description et non à aria-describedby)
