### PR TITLE
fix(VIcon): avertissement de problème d'hydratation

### DIFF
--- a/src/components/VIcon/VIcon.vue
+++ b/src/components/VIcon/VIcon.vue
@@ -54,7 +54,7 @@ const finalColor = computed(() => {
   <Icon
     ref="icon"
     :icon="finalName"
-    :style="{ fontSize, verticalAlign, display }"
+    :style="{ fontSize, verticalAlign, display, color: finalColor }"
     :aria-label="label"
     class="vicon"
     :class="{
@@ -75,9 +75,6 @@ const finalColor = computed(() => {
 </template>
 
 <style scoped>
-.vicon {
-  color: v-bind(finalColor);
-}
 .vicon-inverse {
   color: #fff;
 }


### PR DESCRIPTION
Fix #1037

Le composant `VIcon` provoque des warnings d'hydration mismatches.

Il semble qu'utiliser `v-bind()` et des styles en ligne (`style`) sur le même élément provoque une différence de rendu entre serveur et client.
Le problème a été relevé du côté de Vue, cf.  https://github.com/vuejs/core/issues/12439

On peut enlever le `v-bind()` et utiliser le `style` existant pour la `color`.