### PR TITLE
fix: correction de l'import du type TitleTag

### DIFF
--- a/src/components/DsfrAccordion/DsfrAccordion.types.ts
+++ b/src/components/DsfrAccordion/DsfrAccordion.types.ts
@@ -1,4 +1,4 @@
-import type { TitleTag } from '@/common-types'
+import type { TitleTag } from '../../common-types'
 
 export type DsfrAccordionProps = {
   id?: string

--- a/src/components/DsfrAlert/DsfrAlert.types.ts
+++ b/src/components/DsfrAlert/DsfrAlert.types.ts
@@ -1,4 +1,4 @@
-import type { TitleTag } from '@/common-types'
+import type { TitleTag } from '../../common-types'
 
 export type DsfrAlertType = 'error' | 'success' | 'warning' | 'info'
 

--- a/src/components/DsfrAlert/docs-demo/DsfrAlertDemo.vue
+++ b/src/components/DsfrAlert/docs-demo/DsfrAlertDemo.vue
@@ -4,7 +4,7 @@ import { ref } from 'vue'
 import type { DsfrAlertType } from '../DsfrAlert.vue'
 import DsfrAlert from '../DsfrAlert.vue'
 
-import type { TitleTag } from '@/common-types'
+import type { TitleTag } from '../../common-types'
 
 const defaultAlerts: {
   [key: string]: {

--- a/src/components/DsfrFooter/DsfrFooterPartners.vue
+++ b/src/components/DsfrFooter/DsfrFooterPartners.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import type { TitleTag } from '@/common-types'
+import type { TitleTag } from '../../common-types'
 
 export type DsfrFooterPartner = {
   href: string


### PR DESCRIPTION
fix https://github.com/dnum-mi/vue-dsfr/issues/1117

J'ai fixé le problème de typing de la façon la plus simple possible 🙂.

Celà dit, je pense qu'une manière plus propre est plus simple serait d'utiliser le plugin [`unplugin-dts`](https://github.com/qmhc/unplugin-dts) à la place de `vue-tsc`. Je peux également faire une PR pour ça, mais ça risque d'être breaking change 😕...