### PR TITLE
Ajoute l'option Rich pour le DsfrRadioButtonSet

### DIFF
--- a/src/components/DsfrRadioButton/DsfrRadioButton.types.ts
+++ b/src/components/DsfrRadioButton/DsfrRadioButton.types.ts
@@ -28,6 +28,7 @@ export type DsfrRadioButtonSetProps = {
   validMessage?: string
   legend?: string
   hint?: string
+  rich?: boolean
   modelValue?: string | number | boolean | undefined
   options?: Omit<DsfrRadioButtonProps, 'modelValue'>[]
   ariaInvalid?: boolean | 'grammar' | 'spelling'

--- a/src/components/DsfrRadioButton/DsfrRadioButtonSet.vue
+++ b/src/components/DsfrRadioButton/DsfrRadioButtonSet.vue
@@ -14,6 +14,7 @@ const props = withDefaults(defineProps<DsfrRadioButtonSetProps>(), {
   validMessage: '',
   legend: '',
   hint: '',
+  rich: false,
   options: () => [],
 })
 
@@ -83,6 +84,7 @@ const describedByElement = computed(() => message.value ? `messages-${props.titl
           :inline="inline"
           :model-value="modelValue"
           @update:model-value="onChange($event as string)"
+          :rich="rich"
         />
       </slot>
 


### PR DESCRIPTION
<img width="1292" height="355" alt="Capture d’écran 2025-10-09 à 15 40 55" src="https://github.com/user-attachments/assets/854663d3-92bd-452d-a3d7-2a4e49c2b645" />

Aujourd'hui il n'est pas possible de faire des radio input "rich" avec `DsfrRadioButtonSet`