### PR TITLE
Correction de l'accessibilité de DsfrPagination

### DIFF
--- a/.storybook/theme.css
+++ b/.storybook/theme.css
@@ -1,6 +1,6 @@
 .sbdocs-a, .sbdocs a, .docblock-argstable-body a {
-  color: #000091 !important;
-  outline-color: #000091 !important;
+  color: #000091;
+  outline-color: #000091;
   --link-underline: 0;
   --link-blank-content: "";
   text-decoration: none;

--- a/src/components/DsfrPagination/DsfrPagination.md
+++ b/src/components/DsfrPagination/DsfrPagination.md
@@ -10,19 +10,24 @@ Le composant `DsfrPagination` est un système de pagination conforme aux bonnes 
 
 ## 📐 Structure
 
-Ce composant affiche des liens pour la première page, la précédente, les pages centrales, la suivante, et la dernière, avec des contrôles adaptatifs selon l'état de la pagination.
+Ce composant affiche des liens vers les pages avoisinant la page courante (mise en avant).
+Il affiche aussi la dernière page de la liste comme dernier élément de la pagination afin que l’usager connaisse le nombre total de pages.
+Il présente un accès rapide vers la première page, la précédente, la suivante, et la dernière, avec des contrôles adaptatifs selon l'état de la pagination.
+Des troncatures sont affichées (éventuellement masquées pour de petits écrans) pour matérialiser les pages ommises.
+Le composant propose aussi l'ajout d'un suffixe au texte du titre (`title` qui sert nottament à l'affichage d'une bulle d'aide) de la page courante pour la mettre en valeur.
 
 ## 🛠️ Props
 
 | Nom              | Type                  | Défaut              | Description                                                                                      |
 |-------------------|-----------------------|---------------------|--------------------------------------------------------------------------------------------------|
-| `pages`          | `Page[]`             | **requis**          | Liste des pages, où chaque page est un objet contenant des informations comme `href` et `label`. |
+| `pages`          | `Page[]`             | **requis**          | Liste des pages, où chaque page est un objet contenant des informations comme `href`, `label` et `title`. |
 | `truncLimit`     | `number`             | `5`                 | Nombre maximum de pages affichées simultanément.                                                |
 | `currentPage`    | `number`             | `0`                 | Index de la page actuellement sélectionnée (commence à `0`).                                    |
 | `firstPageTitle` | `string`             | `'Première page'`   | Texte d'info-bulle pour le lien de la première page.                                            |
 | `lastPageTitle`  | `string`             | `'Dernière page'`   | Texte d'info-bulle pour le lien de la dernière page.                                            |
 | `nextPageTitle`  | `string`             | `'Page suivante'`   | Texte d'info-bulle pour le lien de la page suivante.                                            |
 | `prevPageTitle`  | `string`             | `'Page précédente'` | Texte d'info-bulle pour le lien de la page précédente.                                          |
+| `currentPageTitleSuffix`  | `string`             | `undefined` | Texte aditionnel d'info-bulle de la page courante.                                          |
 
 ## 📡Événements
 

--- a/src/components/DsfrPagination/DsfrPagination.spec.ts
+++ b/src/components/DsfrPagination/DsfrPagination.spec.ts
@@ -1,11 +1,20 @@
 import { fireEvent, render } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
 
 import VIcon from '../VIcon/VIcon.vue'
 
 import Pagination from './DsfrPagination.vue'
 
+function makePages (n: number) {
+  return Array.from({ length: n }, (_, i) => ({
+    label: String(i + 1),
+    href: `#p${i + 1}`,
+    title: `page ${i + 1}`,
+  }))
+}
+
 describe('DsfrPagination', () => {
-  it('should render a list of links to give quick access to several pages', async () => {
+  it('should render a list of links to give quick access to several pages without title if undefined', async () => {
     // Given
     const pages = [
       { label: '1', href: '/#' },
@@ -17,7 +26,7 @@ describe('DsfrPagination', () => {
     const currentPage = 1
 
     // When
-    const { getByText, emitted } = render(Pagination, {
+    const { getByText, getAllByRole, emitted } = render(Pagination, {
       global: {
         components: {
           VIcon,
@@ -31,9 +40,207 @@ describe('DsfrPagination', () => {
 
     const thirdLink = getByText('3')
     await fireEvent.click(thirdLink)
+    const pageLinks = getAllByRole('link', { name: /\d+/ })
 
     // Then
     expect(emitted()['update:current-page']).toBeTruthy()
     expect(emitted()['update:current-page'][0][0]).toBe(2)
+    pageLinks.forEach((link) => {
+      expect(link.getAttribute('title')).toBe(null)
+    })
+  })
+
+  it('should render a list of links without title if equal to label', async () => {
+    // Given
+    const pages = [
+      { label: '1', title: '1', href: '/#' },
+      { label: '2', title: '2', href: '/#' },
+      { label: '3', title: '3', href: '/#' },
+      { label: '4', title: '4', href: '/#' },
+      { label: '5', title: '5', href: '/#' },
+    ]
+    const currentPage = 1
+
+    // When
+    const { getAllByRole } = render(Pagination, {
+      global: {
+        components: {
+          VIcon,
+        },
+      },
+      props: {
+        pages,
+        currentPage,
+        currentPageTitleSuffix: ' - page courante',
+      },
+    })
+
+    const pageLinks = getAllByRole('link', { name: /\d+/ })
+
+    // Then
+    pageLinks.forEach((link) => {
+      if (link.ariaCurrent !== 'page') {
+        expect(link.getAttribute('title')).toBe(null)
+      } else {
+        expect(link.getAttribute('title')).equal('2 - page courante')
+      }
+    })
+  })
+
+  it('should render a list of links with appropriate title', async () => {
+    // Given
+    const pages = makePages(6)
+
+    // When
+    const { getByRole } = render(Pagination, {
+      global: { components: { VIcon } },
+      props: {
+        pages,
+        currentPage: 2,
+        truncLimit: 4,
+        firstPageTitle: 'Première page',
+        lastPageTitle: 'Dernière page',
+        nextPageTitle: 'Page suivante',
+        prevPageTitle: 'Page précédente',
+        currentPageTitleSuffix: ' - page courante',
+        ellipsisTitle: 'Pages intermédiaires non affichées',
+      },
+    })
+
+    const nextLink = getByRole('link', { name: 'Page suivante' })
+    const prevLink = getByRole('link', { name: 'Page précédente' })
+    const firstLink = getByRole('link', { name: 'Première page' })
+    const lastLink = getByRole('link', { name: 'Dernière page' })
+    const currentLink = getByRole('link', { current: 'page' })
+    // Then
+    expect(nextLink.getAttribute('title')).toBe('Page suivante')
+    expect(prevLink.getAttribute('title')).toBe('Page précédente')
+    expect(firstLink.getAttribute('title')).toBe('Première page')
+    expect(lastLink.getAttribute('title')).toBe('Dernière page')
+    expect(currentLink.getAttribute('title')).toBe('page 3 - page courante')
+  })
+
+  it('renders navigation with default aria-label', () => {
+    // Given
+    const pages = makePages(3)
+
+    // When
+    const { getByRole } = render(Pagination, {
+      global: { components: { VIcon } },
+      props: { pages },
+    })
+
+    // Then
+    expect(getByRole('navigation', { name: 'Pagination' })).toBeTruthy()
+  })
+
+  it('emits update:current-page when using navigation controls and page links', async () => {
+    // Given
+    const pages = makePages(5)
+
+    // When
+    const { getByRole, getByText, emitted } = render(Pagination, {
+      global: { components: { VIcon } },
+      props: { pages, currentPage: 1 },
+    })
+
+    await fireEvent.click(getByRole('link', { name: 'Page suivante' })) // next -> 2
+    await fireEvent.click(getByRole('link', { name: 'Page précédente' })) // prev -> 0
+    await fireEvent.click(getByRole('link', { name: 'Première page' })) // first -> 0
+    await fireEvent.click(getByRole('link', { name: 'Dernière page' })) // last -> pages.length - 1
+    await fireEvent.click(getByText('3')) // specific page -> index 2
+
+    // Then
+    const emits = emitted()['update:current-page']
+    expect(emits).toBeTruthy()
+    expect(emits![0][0]).toBe(2)
+    expect(emits![1][0]).toBe(0)
+    expect(emits![2][0]).toBe(0)
+    expect(emits![3][0]).toBe(pages.length - 1)
+    expect(emits![4][0]).toBe(2)
+  })
+
+  it('applies truncation and shows ellipsis when pages.length > truncLimit', () => {
+    // Given
+    const pages = makePages(15)
+    const currentPage = 5
+
+    // When
+    const { getAllByRole, getAllByText } = render(Pagination, {
+      global: { components: { VIcon } },
+      props: { pages, currentPage },
+    })
+
+    // Then
+    // find links whose accessible name contains a digit (covers cases with ellipsis + digits)
+    const pageLinks = getAllByRole('link', { name: /\d+/ })
+    const ellipsis = getAllByText('...')
+
+    const firstEllipsis = ellipsis[0].textContent?.trim() ?? ''
+    expect(firstEllipsis.includes('...')).toBe(true)
+
+    expect(pageLinks.length).toBeLessThan(pages.length)
+
+    const lastEllipsis = ellipsis[1].textContent?.trim() ?? ''
+    expect(lastEllipsis.includes('...')).toBe(true)
+  })
+
+  it('should have correct title attributes on page links', () => {
+    // Given
+    const pages = makePages(5)
+
+    // When
+    const { getAllByRole } = render(Pagination, {
+      global: { components: { VIcon } },
+      props: { pages, currentPage: 0, currentPageTitleSuffix: ' - page courante' },
+    })
+
+    // Then
+    const pageLinks = getAllByRole('link', { name: /\d+/ })
+    pageLinks.forEach((link, index) => {
+      if (link.ariaCurrent === 'page') {
+        expect(link.getAttribute('title')).toBe(`page ${index + 1} - page courante`)
+      } else {
+        expect(link.getAttribute('title')).toBe(`page ${index + 1}`)
+      }
+    })
+  })
+
+  it('should have correct title attributes on page links when titles are equal to labels', () => {
+    // Given
+    const pages = makePages(5).map((page) => ({ ...page, title: page.label }))
+
+    // When
+    const { getAllByRole } = render(Pagination, {
+      global: { components: { VIcon } },
+      props: { pages, currentPage: 0, currentPageTitleSuffix: ' - page courante' },
+    })
+
+    // Then
+    const pageLinks = getAllByRole('link', { name: /\d+/ })
+    pageLinks.forEach((link) => {
+      if (link.ariaCurrent !== 'page') {
+        expect(link.getAttribute('title')).toBe(null)
+      } else {
+        expect(link.getAttribute('title')).equal('1 - page courante')
+      }
+    })
+  })
+
+  it('should disable navigation controls and add disabled class at boundaries', () => {
+    // Given
+    const pages = makePages(5)
+
+    // When
+    const { getByRole } = render(Pagination, {
+      global: { components: { VIcon } },
+      props: { pages, currentPage: 0 },
+    })
+
+    // Then
+    expect(getByRole('link', { name: 'Première page' }).getAttribute('aria-disabled')).toBe('true')
+    expect(getByRole('link', { name: 'Première page' }).classList.contains('fr-pagination__link--disabled')).toBe(true)
+    expect(getByRole('link', { name: 'Page précédente' }).getAttribute('aria-disabled')).toBe('true')
+    expect(getByRole('link', { name: 'Page précédente' }).classList.contains('fr-pagination__link--disabled')).toBe(true)
   })
 })

--- a/src/components/DsfrPagination/DsfrPagination.stories.ts
+++ b/src/components/DsfrPagination/DsfrPagination.stories.ts
@@ -43,6 +43,11 @@ const meta = {
       description:
         'Permet de limiter le nombre de pages affichées dans la pagination (avec un maximum de 5 pages)',
     },
+    currentPageTitleSuffix: {
+      control: 'text',
+      description:
+        'Permet d’ajouter un suffixe au titre de la page courante pour indiquer à l’utilisateur qu’il se trouve sur cette page',
+    },
     'onUpdate:currentPage': fn(),
   },
 } satisfies Meta<typeof DsfrPagination>
@@ -68,6 +73,8 @@ const render = (args: any) => ({
       <DsfrPagination
         :pages="args.pages"
         v-model:current-page="currentPage"
+        :trunc-limit="args.truncLimit"
+        :current-page-title-suffix="args.currentPageTitleSuffix"
       />
   `,
 })
@@ -102,6 +109,7 @@ export const Pagination: Story = {
         title: 'Page 5',
       },
     ],
+    truncLimit: 5,
     currentPage: 0,
   },
   play: async ({ canvasElement, args }) => {
@@ -167,6 +175,7 @@ export const PaginationTronquee: Story = {
         title: 'Page 9',
       },
     ],
-    currentPage: 4,
+    truncLimit: 3,
+    currentPage: 3,
   },
 }

--- a/src/components/DsfrPagination/DsfrPagination.types.ts
+++ b/src/components/DsfrPagination/DsfrPagination.types.ts
@@ -1,4 +1,8 @@
-export type Page = { href?: string, label: string, title: string }
+export type Page = {
+  href?: string
+  label: string
+  title: string
+}
 
 export type DsfrPaginationProps = {
   pages: Page[]
@@ -7,6 +11,7 @@ export type DsfrPaginationProps = {
   lastPageTitle?: string
   nextPageTitle?: string
   prevPageTitle?: string
+  currentPageTitleSuffix?: string
   truncLimit?: number
   ariaLabel?: string
 }

--- a/src/components/DsfrPagination/DsfrPagination.vue
+++ b/src/components/DsfrPagination/DsfrPagination.vue
@@ -29,6 +29,7 @@ const endIndex = computed(() => {
 const displayedPages = computed(() => {
   return props.pages.length > props.truncLimit ? props.pages.slice(startIndex.value, endIndex.value + 1) : props.pages
 })
+const lastPage = props.pages[props.pages.length - 1]
 
 const updatePage = (index: number) => emit('update:current-page', index)
 const toPage = (index: number) => updatePage(index)
@@ -51,6 +52,7 @@ const isCurrentPage = (page: Page) => props.pages.indexOf(page) === props.curren
           :href="pages[0]?.href"
           class="fr-pagination__link fr-pagination__link--first"
           :class="{ 'fr-pagination__link--disabled': currentPage === 0 }"
+          :title="firstPageTitle"
           :aria-disabled="currentPage === 0 ? true : undefined"
           @click.prevent="currentPage === 0 ? null : tofirstPage()"
         >
@@ -62,9 +64,13 @@ const isCurrentPage = (page: Page) => props.pages.indexOf(page) === props.curren
           :href="pages[Math.max(currentPage - 1, 0)]?.href"
           class="fr-pagination__link fr-pagination__link--prev fr-pagination__link--lg-label"
           :class="{ 'fr-pagination__link--disabled': currentPage === 0 }"
+          :title="prevPageTitle"
           :aria-disabled="currentPage === 0 ? true : undefined"
           @click.prevent="currentPage === 0 ? null : toPreviousPage()"
         >{{ prevPageTitle }}</a>
+      </li>
+      <li v-if="startIndex > 0 ">
+        <span class="fr-pagination__link fr-unhidden-lg">...</span>
       </li>
       <li
         v-for="(page, idx) in displayedPages"
@@ -73,19 +79,31 @@ const isCurrentPage = (page: Page) => props.pages.indexOf(page) === props.curren
         <a
           :href="page?.href"
           class="fr-pagination__link fr-unhidden-lg"
+          :title="(isCurrentPage(page) && page.title) ? (currentPageTitleSuffix) ? page.title + currentPageTitleSuffix : page.title : (page.title !== page.label) ? page.title : undefined"
           :aria-current="isCurrentPage(page) ? 'page' : undefined"
           @click.prevent="toPage(pages.indexOf(page))"
         >
-          <span v-if="displayedPages.indexOf(page) === 0 && startIndex > 0 ">...</span>
           {{ page.label }}
-          <span v-if="displayedPages.indexOf(page) === displayedPages.length - 1 && endIndex < pages.length - 1">...</span>
         </a>
+      </li>
+      <li v-if="endIndex < pages.length - 2">
+        <span class="fr-pagination__link fr-unhidden-lg">...</span>
+      </li>
+      <li v-if="endIndex < pages.length - 1">
+        <a
+          :href="lastPage.href"
+          class="fr-pagination__link fr-unhidden-lg"
+          :title="(lastPage.title !== lastPage.label) ? lastPage.title : undefined"
+          :aria-current="isCurrentPage(lastPage) ? 'page' : undefined"
+          @click.prevent="toPage(props.pages.indexOf(lastPage))"
+        >{{ lastPage.label }}</a>
       </li>
       <li>
         <a
           :href="pages[Math.min(currentPage + 1, pages.length - 1)]?.href"
           class="fr-pagination__link fr-pagination__link--next fr-pagination__link--lg-label"
           :class="{ 'fr-pagination__link--disabled': currentPage === pages.length - 1 }"
+          :title="nextPageTitle"
           :disabled="currentPage === pages.length - 1 ? true : undefined"
           :aria-disabled="currentPage === pages.length - 1 ? true : undefined"
           @click.prevent="currentPage === pages.length - 1 ? null : toNextPage()"
@@ -96,6 +114,7 @@ const isCurrentPage = (page: Page) => props.pages.indexOf(page) === props.curren
           :href="pages.at(-1)?.href"
           class="fr-pagination__link fr-pagination__link--last"
           :class="{ 'fr-pagination__link--disabled': currentPage === pages.length - 1 }"
+          :title="lastPageTitle"
           :disabled="currentPage === pages.length - 1 ? true : undefined"
           :aria-disabled="currentPage === pages.length - 1 ? true : undefined"
           @click.prevent="currentPage === pages.length - 1 ? null : toLastPage()"
@@ -110,8 +129,8 @@ const isCurrentPage = (page: Page) => props.pages.indexOf(page) === props.curren
 <style scoped>
 .fr-pagination__link:hover {
   background-image: linear-gradient(
-    deg, rgba(224,224,224,0.5), rgba(224,224,224,0.5));
-}
+  deg, rgba(224,224,224,0.5), rgba(224,224,224,0.5));
+  }
 .fr-pagination__link--disabled {
   color: currentColor;
   cursor: not-allowed;

--- a/src/components/DsfrPagination/docs-demo/DsfrPaginationExample.vue
+++ b/src/components/DsfrPagination/docs-demo/DsfrPaginationExample.vue
@@ -5,19 +5,19 @@ import { ref } from 'vue'
 
 import DsfrPagination from '../DsfrPagination.vue'
 
-const currentPage = ref(1)
+const currentPage = ref(5)
 
 const pages = ref<Page[]>([
-  { title: '1', href: '#1', label: '1' },
-  { title: '2', href: '#2', label: '2' },
-  { title: '3', href: '#3', label: '3' },
-  { title: '4', href: '#4', label: '4' },
-  { title: '5', href: '#5', label: '5' },
-  { title: '6', href: '#6', label: '6' },
-  { title: '7', href: '#7', label: '7' },
-  { title: '8', href: '#8', label: '8' },
-  { title: '9', href: '#9', label: '9' },
-  { title: '10', href: '#10', label: '10' },
+  { title: 'Lien vers la page 1', href: '#1', label: '1' },
+  { title: 'Lien vers la page 2', href: '#2', label: '2' },
+  { title: 'Lien vers la page 3', href: '#3', label: '3' },
+  { title: 'Lien vers la page 4', href: '#4', label: '4' },
+  { title: 'Lien vers la page 5', href: '#5', label: '5' },
+  { title: 'Lien vers la page 6', href: '#6', label: '6' },
+  { title: 'Lien vers la page 7', href: '#7', label: '7' },
+  { title: 'Lien vers la page 8', href: '#8', label: '8' },
+  { title: 'Lien vers la page 9', href: '#9', label: '9' },
+  { title: 'Lien vers la page 10', href: '#10', label: '10' },
 ])
 </script>
 
@@ -25,5 +25,7 @@ const pages = ref<Page[]>([
   <DsfrPagination
     v-model:current-page="currentPage"
     :pages="pages"
+    :trunc-limit="2"
+    current-page-title-suffix=" - page courante"
   />
 </template>


### PR DESCRIPTION
La correction de DsfrPagination dans la PR #1136 supprime les titles.
Mais ceux-ci sont utiles dans le cas ou title et  label sont différents.
C'est aussi utile pour les bulle d'information des raccourcis vers la première page, la dernière page', la page suivante et la page précédente, dont le texte est respectivement transformé à l'écran en `|<`, `>|`, `<<`, `>>`

Cette PR corrige ce point mais aussi :
- la présence de la dernière page dans la liste comme recommandé dans la [doc DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/pagination)
- les troncatures sont maintenant indépendantes des liens vers les pages (voir [code d'exemple du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/pagination/code-de-la-pagination))
- une prop currentPageTitleSuffix est proposé pour ajouter une indication concernant la page courante dans sa bulle d'aide
- les tests et la doc vitepress et storybook a été corrigée