### PR TITLE
DsfrRange : mettre à jour la taille de la barre à chaque redimensionnement de la fenetre

### DIFF
--- a/demo-app/views/AppForm.vue
+++ b/demo-app/views/AppForm.vue
@@ -131,6 +131,15 @@ const cbOptions: DsfrCheckboxSetProps['options'] = [
       </template>
     </DsfrInput>
 
+    <DsfrRange
+      label="Exemple de DsfrRange"
+      v-model="rangeValue"
+      :min="0"
+      :max="100"
+      :step="5"
+      :small="false"
+    />
+
     <h2>ChecboxSet :</h2>
     <DsfrCheckboxSet
       v-model="selectedCheckboxes"


### PR DESCRIPTION
- **fix: 🐛 utilisation native de l'ancre pour les liens d'évitement**
- **fix: correction de l'import du type TitleTag**
- **fix(DsfrAlertDemo): 🐛 corrige import**
- **fix(range): ♻️ remplace useResizeObserver par ResizeObserver natif**
