### PR TITLE
ci: 🔗 ajoute vérification PR liée à une issue

### DIFF
--- a/.github/workflows/check-pr-linked-issue.yml
+++ b/.github/workflows/check-pr-linked-issue.yml
@@ -1,0 +1,39 @@
+name: Check PR linked to issue
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  check-linked-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if PR is linked to an issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+
+            // Vérifier si la PR a des issues liées via l'API GitHub
+            const { data: linkedIssues } = await github.rest.repos.listPullRequestAssociatedIssues({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+
+            // Vérifier aussi dans le corps de la PR (mots-clés comme "closes #123", "fixes #456")
+            const prBody = pullRequest.body || '';
+            const issueKeywords = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
+            const bodyMatches = prBody.match(issueKeywords);
+
+            const hasLinkedIssues = linkedIssues.length > 0 || bodyMatches;
+
+            if (!hasLinkedIssues) {
+              core.setFailed('❌ Cette PR doit être liée à une issue. Utilisez des mots-clés comme "closes #123" ou "fixes #456" dans la description, ou liez manuellement une issue dans l’interface GitHub.');
+            } else {
+              console.log('✅ PR correctement liée à une ou plusieurs issues');
+            }


### PR DESCRIPTION
## Pourquoi les changements ont été faits :
- Renforce la traçabilité entre le code et les besoins métier
- Assure qu'aucune PR n'est mergée sans contexte documenté
- Améliore la gestion des issues et la documentation du projet
- Force une meilleure organisation du workflow de développement

## Quelles modifications ont été apportées :
- Ajoute le workflow `check-pr-linked-issue.yml`
- Vérifie automatiquement si une PR est liée à une issue
- Supporte les liens manuels via l'interface GitHub
- Détecte les mots-clés comme "closes #123", "fixes #456"
- Bloque les PR sans issue associée avec un message explicite
