### PR TITLE
docs: 📝 renomme Guide du développeur en Guide du contributeur

### DIFF
--- a/.github/workflows/check-pr-linked-issue.yml
+++ b/.github/workflows/check-pr-linked-issue.yml
@@ -18,6 +18,34 @@ jobs:
               pull_number: context.issue.number,
             });
 
+            // Vérifier les issues liées via l'interface GitHub avec GraphQL
+            const query = `
+              query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    closingIssuesReferences(first: 50) {
+                      nodes {
+                        number
+                        title
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+
+            let linkedIssuesFromUI = [];
+            try {
+              const result = await github.graphql(query, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                number: context.issue.number,
+              });
+              linkedIssuesFromUI = result.repository.pullRequest.closingIssuesReferences.nodes;
+            } catch (error) {
+              console.log('Erreur lors de la récupération des issues liées via GraphQL:', error.message);
+            }
+
             // Vérifier dans le corps de la PR (mots-clés comme "closes #123", "fixes #456")
             const prBody = pullRequest.body || '';
             const prTitle = pullRequest.title || '';
@@ -32,12 +60,15 @@ jobs:
             const simpleIssueRef = /(?:^|\s)#(\d+)(?:\s|$|-)/g;
             const titleIssueRefs = prTitle.match(simpleIssueRef);
 
-            const hasLinkedIssues = bodyMatches || titleMatches || titleIssueRefs;
+            const hasLinkedIssues = linkedIssuesFromUI.length > 0 || bodyMatches || titleMatches || titleIssueRefs;
 
             if (!hasLinkedIssues) {
-              core.setFailed('❌ Cette PR doit être liée à une issue. Utilisez des mots-clés comme "closes #123" ou "fixes #456" dans la description, ou référencez une issue dans le titre avec "#123".');
+              core.setFailed('❌ Cette PR doit être liée à une issue. Utilisez des mots-clés comme "closes #123" ou "fixes #456" dans la description, référencez une issue dans le titre avec "#123", ou liez une issue via l\'interface GitHub.');
             } else {
               console.log('✅ PR correctement liée à une ou plusieurs issues');
+              if (linkedIssuesFromUI.length > 0) {
+                console.log('Issues liées via l\'interface GitHub:', linkedIssuesFromUI.map(issue => `#${issue.number} - ${issue.title}`));
+              }
               if (bodyMatches) console.log('Issues trouvées dans le body:', bodyMatches);
               if (titleMatches) console.log('Issues trouvées dans le titre:', titleMatches);
               if (titleIssueRefs) console.log('Références d\'issues dans le titre:', titleIssueRefs);

--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -68,7 +68,7 @@ const guideItems = [
     link: '/guide/migrations.md',
   },
   {
-    text: 'Guide du développeur',
+    text: 'Guide du contributeur',
     link: '/guide/guide-developpeur.md',
   },
 ]
@@ -488,7 +488,7 @@ export default defineConfig({
         text: 'Guides',
         items: [
           { text: 'Guide de l’utilisateur', link: '/guide/pour-commencer' },
-          { text: 'Guide du développeur', link: '/guide/guide-developpeur' },
+          { text: 'Guide du contributeur', link: '/guide/guide-developpeur' },
         ],
       },
       {

--- a/docs/guide/guide-developpeur.md
+++ b/docs/guide/guide-developpeur.md
@@ -1,14 +1,31 @@
-# Guide du développeur
+# Guide du contributeur
 
 ## Comment contribuer
 
 ::: info NOTE
 
-Ceci est le guide du développeur pour contribuer au projet de cette bibliothèque.
+Ceci est le guide du contributeur pour contribuer au projet de cette bibliothèque.
 Si vous cherchez à utiliser cette bibliothèque, veuillez vous référer au
-[Guide d’utilisation](./pour-commencer.md).
+[Guide d'utilisation](./pour-commencer.md).
 
 :::
+
+## Langue et communication
+
+**Tout le contenu de ce projet doit être rédigé en français**, y compris :
+
+- Messages de commits
+- Commentaires dans le code
+- Documentation
+- Échanges sur GitHub (issues, pull requests, discussions)
+- Noms de fichiers lorsque c'est pertinent
+
+**Seules exceptions autorisées et même recommandées :**
+
+- **Noms de branches** : en anglais pour qu'ils soient plus courts et standardisés (ex: `feat/button-component`, `fix/accessibility-issue`)
+- **Noms de variables et fonctions** : en anglais selon les conventions de développement (ex: `handleClick`, `isVisible`, `userConfig`)
+
+Cette approche permet de maintenir la cohérence du projet tout en respectant les bonnes pratiques de développement internationales.
 
 ### TL;DR
 

--- a/docs/guide/pour-commencer.md
+++ b/docs/guide/pour-commencer.md
@@ -2,8 +2,8 @@
 
 ::: info NOTE
 
-Ceci est le guide d̛’utilisation de la bibliothèque. Si vous cherchez à contribuer, se référer au
-[Guide du développeur](./guide-developpeur).
+Ceci est le guide d̛'utilisation de la bibliothèque. Si vous cherchez à contribuer, se référer au
+[Guide du contributeur](./guide-developpeur).
 
 :::
 


### PR DESCRIPTION
## Pourquoi les changements ont été faits :
- Clarification du rôle : « contributeur » est plus précis que « développeur »
- Ajout de directives claires sur l'usage du français dans le projet
- Standardisation de la terminologie dans toute la documentation
- Amélioration de l'onboarding des nouveaux contributeurs

## Quelles modifications ont été apportées :
- Renommage « Guide du développeur » → « Guide du contributeur » dans tous les fichiers
- Ajout d'une section « Langue et communication » avec les règles d'usage du français
- Précision des exceptions autorisées (noms de branches et variables en anglais)
- Mise à jour des références dans la configuration VitePress et documentation