### PR TITLE
ci: ajoute exception pour PR develop vers main

### DIFF
--- a/.github/workflows/check-pr-linked-issue.yml
+++ b/.github/workflows/check-pr-linked-issue.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   check-linked-issue:
     runs-on: ubuntu-latest
+    # Exception : les PR de develop vers main n'ont pas besoin d'être liées à une issue
+    if: github.head_ref != 'develop' || github.base_ref != 'main'
     steps:
       - name: Check if PR is linked to an issue
         uses: actions/github-script@v7


### PR DESCRIPTION
Cette PR améliore le workflow de vérification des issues liées en ajoutant une exception pour les PR de develop vers main.

## Changements
- Exception pour develop → main dans check-pr-linked-issue.yml 
- Maintient la vérification pour toutes les autres PR
- Améliore la fluidité du processus de release

## Justification
Les PR de develop vers main sont des releases qui agrègent plusieurs fonctionnalités déjà tracées individuellement. Elles n'ont pas besoin d'être liées à une issue spécifique.