### PR TITLE
fix(tooltip): empêche la soumission de formulaire avec type="button"

### DIFF
--- a/src/components/DsfrTooltip/DsfrTooltip.vue
+++ b/src/components/DsfrTooltip/DsfrTooltip.vue
@@ -155,6 +155,7 @@ onUnmounted(() => {
     :class="onHover ? 'fr-link' : 'fr-btn  fr-btn--tooltip'"
     :aria-describedby="id"
     :href="onHover ? '#' : undefined"
+    :type="onHover ? undefined : 'button'"
     @click="onClick()"
     @mouseleave="onMouseLeave()"
     @focus="onMouseEnterHandler($event)"


### PR DESCRIPTION
## Problème résolu

Le composant DsfrTooltip en mode clic utilise un bouton qui, sans type explicite, peut déclencher la soumission d'un formulaire englobant.

## Solution

Ajoute `type="button"` explicitement pour les tooltips en mode clic pour éviter tout comportement de soumission involontaire.

## Tests

- ✅ Tooltip en mode hover : comportement inchangé (lien)
- ✅ Tooltip en mode clic : plus de soumission de formulaire
- ✅ Fonctionnalité tooltip préservée dans tous les cas

Closes #1157