### PR TITLE
refactor(checkbox): fusionne les balises script en une seule

### DIFF
--- a/src/components/DsfrCheckbox/DsfrCheckboxSet.vue
+++ b/src/components/DsfrCheckbox/DsfrCheckboxSet.vue
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script lang="ts" setup>
 import type { DsfrCheckboxSetProps } from './DsfrCheckbox.types'
 
 import { computed } from 'vue'
@@ -8,9 +8,6 @@ import { useRandomId } from '../../utils/random-utils'
 import DsfrCheckbox from './DsfrCheckbox.vue'
 
 export type { DsfrCheckboxSetProps }
-</script>
-
-<script lang="ts" setup>
 const props = withDefaults(defineProps<DsfrCheckboxSetProps>(), {
   titleId: () => useRandomId('checkbox', 'set'),
   errorMessage: '',


### PR DESCRIPTION
## Problème résolu

Le composant DsfrCheckboxSet avait deux balises `<script>` séparées qui peuvent être fusionnées en une seule pour plus de simplicité.

## Solution

Fusion des deux balises script en une seule `<script lang="ts" setup>` qui contient tous les imports et exports.

## Avantages

- ✅ Code plus simple et moderne
- ✅ Meilleure lisibilité 
- ✅ Cohérence avec les standards Vue 3 Composition API
- ✅ Élimination de la verbosité inutile

## Tests

- ✅ Aucun changement fonctionnel
- ✅ Refactoring purement structurel
- ✅ Tous les imports/exports préservés

Closes #1159