### PR TITLE
fix(tabs): ajoute inheritAttrs false pour éviter duplication d'attributs

### DIFF
--- a/src/components/DsfrTabs/DsfrTabItem.vue
+++ b/src/components/DsfrTabs/DsfrTabItem.vue
@@ -5,11 +5,10 @@ import VIcon from '../VIcon/VIcon.vue'
 
 import { registerTabKey } from './injection-key'
 
-export type DsfrTabItemProps = {
-  panelId: string
-  tabId: string
-  icon?: string
-}
+defineOptions({
+  inheritAttrs: false,
+})
+
 const props = withDefaults(defineProps<DsfrTabItemProps>(), {
   icon: undefined,
 })
@@ -31,6 +30,12 @@ defineSlots<{
   /** Slot par défaut pour le contenu de l’onglet. Sera dans `<button class="fr-tabs__tab">` */
   default?: () => any
 }>()
+
+export type DsfrTabItemProps = {
+  panelId: string
+  tabId: string
+  icon?: string
+}
 
 const button = ref<HTMLButtonElement | null>(null)
 


### PR DESCRIPTION
## Problème résolu

Le composant DsfrTabItem utilisait v-bind="$attrs" sur le bouton interne sans définir inheritAttrs: false, ce qui causait une duplication des attributs sur la racine ET le bouton.

## Solution

Ajoute defineOptions({ inheritAttrs: false }) pour s'assurer que les attributs ne sont appliqués que sur le bouton ciblé via v-bind="$attrs".

## Avantages

- ✅ Élimine la duplication d'attributs dans le DOM
- ✅ Évite les conflits d'attributs potentiels  
- ✅ Améliore la propreté du HTML généré
- ✅ Comportement plus prévisible

## Tests

- ✅ Les attributs sont maintenant uniquement sur le bouton
- ✅ Aucun changement fonctionnel visible
- ✅ Meilleure structure DOM

Closes #1161