### PR TITLE
feat(DsfrRadioButtonSet): ✨ ajoute la propriété rich pour les radio buttons enrichis

### DIFF
--- a/src/components/DsfrRadioButton/DsfrRadioButton.types.ts
+++ b/src/components/DsfrRadioButton/DsfrRadioButton.types.ts
@@ -28,6 +28,7 @@ export type DsfrRadioButtonSetProps = {
   validMessage?: string
   legend?: string
   hint?: string
+  rich?: boolean
   modelValue?: string | number | boolean | undefined
   options?: Omit<DsfrRadioButtonProps, 'modelValue'>[]
   ariaInvalid?: boolean | 'grammar' | 'spelling'

--- a/src/components/DsfrRadioButton/DsfrRadioButtonSet.vue
+++ b/src/components/DsfrRadioButton/DsfrRadioButtonSet.vue
@@ -83,6 +83,7 @@ const describedByElement = computed(() => message.value ? `messages-${props.titl
           :small="small"
           :inline="inline"
           :model-value="modelValue"
+          :rich="rich"
           @update:model-value="onChange($event as string)"
         />
       </slot>


### PR DESCRIPTION
## Description

Cette PR ajoute la propriété `rich` au composant `DsfrRadioButtonSet` pour permettre l'utilisation de radio buttons avec du contenu enrichi.

## Problème résolu

Actuellement, il n'est pas possible de créer des radio buttons "rich" (avec du contenu enrichi) avec le composant `DsfrRadioButtonSet`. Cette limitation empêche la création d'interfaces utilisateur plus riches et expressives.

## Modifications apportées

- ✅ Ajout de la propriété `rich?: boolean` dans `DsfrRadioButtonSetProps`
- ✅ Transmission de la prop `rich` aux composants `DsfrRadioButton` enfants
- ✅ Respect des conventions du projet (pas de `withDefaults` pour les booléens false)
- ✅ Commit avec co-auteur Clément Prod'homme

## Fonctionnement

La propriété `rich` est optionnelle et par défaut à `false`. Quand elle est définie à `true`, elle est transmise à tous les composants `DsfrRadioButton` enfants, leur permettant d'afficher du contenu enrichi.

## Critères d'acceptation

- [x] La propriété `rich` est optionnelle et par défaut à `false`
- [x] La prop est correctement transmise aux composants `DsfrRadioButton` enfants
- [x] Le comportement existant n'est pas affecté
- [x] Respect des conventions de commits du projet

## Co-auteur

Cette fonctionnalité est basée sur le travail de @cprodhomme (Clément Prod'homme) de la PR #1133.

## Checklist

- [x] Le code respecte les conventions du projet
- [x] Les modifications sont documentées dans le message de commit
- [x] La branche part de `develop` et fusionne vers `develop`
- [x] Le commit inclut le co-auteur approprié