### PR TITLE
fix(release): 🐛 corrige erreur semantic-release avec type refactor manquant

### DIFF
--- a/package.json
+++ b/package.json
@@ -201,6 +201,7 @@
               { "type": "perf", "section": "⚡ Améliorations de performance" },
               { "type": "ci", "section": "👷 CI/CD" },
               { "type": "test", "section": "✅ Tests" },
+              { "type": "refactor", "hidden": true },
               { "type": "style", "hidden": true }
             ]
           }


### PR DESCRIPTION
Fixes #1172

## Description

Cette PR corrige l'erreur de semantic-release qui se produisait lors du traitement des commits de type `refactor`.

## Problème résolu

L'erreur `Date.prototype.toString called on incompatible receiver` était causée par une incohérence dans la configuration de semantic-release : le plugin `@semantic-release/commit-analyzer` reconnaissait les commits `refactor`, mais le plugin `@semantic-release/release-notes-generator` n'avait pas la configuration correspondante.

## Solution

Ajout de la configuration manquante pour le type `refactor` dans la section `presetConfig.types` du plugin `@semantic-release/release-notes-generator` :

```json
{
  "type": "refactor",
  "hidden": true
}
```

## Impact

- ✅ Résout l'erreur de semantic-release
- ✅ Les commits de type `refactor` sont maintenant traités correctement
- ✅ Les commits de refactoring restent cachés dans les notes de version (comportement souhaité)

## Tests

La configuration a été testée et l'erreur ne se produit plus lors de l'exécution de semantic-release.