### PR TITLE
lint(DsfrFooter): 🚨 corrige l'indentation dans DsfrFooter.spec.ts

### DIFF
--- a/src/components/DsfrFooter/DsfrFooter.spec.ts
+++ b/src/components/DsfrFooter/DsfrFooter.spec.ts
@@ -142,7 +142,7 @@ describe('DsfrFooter', () => {
     expect(getByTestId(testIdMentionsLegales)).toHaveClass('fr-footer__bottom-link')
   })
 
-   it('should render provided mandatoryLinks when passed as prop', async () => {
+  it('should render provided mandatoryLinks when passed as prop', async () => {
     // Given
     const mandatoryLinks = [
       { label: 'Cookies', to: '/cookies' },


### PR DESCRIPTION

## Résumé

Corrige une erreur d'indentation dans le fichier de test DsfrFooter.spec.ts.

## Changements

- Correction de l'indentation du test 'should render provided mandatoryLinks when passed as prop' (ligne 145)
- Suppression de l'espace en trop au début de la ligne

## Test plan

- [x] Tests unitaires passent
- [x] Linter ne remonte plus d'erreur

Fixes #1194