### PR TITLE
feat(DsfrCallout): ✨ ajoute le support de la balise <p> pour le titre

### DIFF
--- a/src/components/DsfrCallout/DsfrCallout.types.ts
+++ b/src/components/DsfrCallout/DsfrCallout.types.ts
@@ -32,7 +32,7 @@ export type DsfrColorAccent =
 export type DsfrCalloutProps = {
   title?: string
   content?: string
-  titleTag?: TitleTag
+  titleTag?: TitleTag | 'p'
   button?: DsfrButtonProps
   icon?: string | VIconProps
   accent?: DsfrColorAccent


### PR DESCRIPTION
## Summary

Ajoute le support de la balise `<p>` pour le titre du composant DsfrCallout, conformément aux évolutions du DSFR 1.14.

## Contexte

Le DSFR version 1.14 permet désormais d'utiliser un `<p>` à la place d'un `<hx>` pour le titre du composant Callout. Cette modification apporte plus de flexibilité dans la structure sémantique du composant.

## Modifications apportées

- Extension du type `titleTag` dans `DsfrCalloutProps` pour accepter `'p'` en plus des balises `TitleTag` existantes
- Utilisation de l'union type `TitleTag | 'p'` pour préserver la compatibilité ascendante

## Test plan

- [x] Vérifier que le composant DsfrCallout accepte `titleTag="p"` sans erreur TypeScript
- [x] Vérifier que les balises de titre classiques (`h1`, `h2`, `h3`, etc.) fonctionnent toujours correctement
- [x] Vérifier le rendu visuel avec `titleTag="p"`
- [x] Exécuter les tests unitaires : `pnpm test`
- [x] Vérifier le linting : `pnpm lint`

Fixes #1224

🤖 Generated with [Claude Code](https://claude.com/claude-code)