### PR TITLE
ci(test): ajoute option retry pour les tests Storybook

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -50,6 +50,7 @@ export default mergeConfig(viteConfig, defineConfig({
             browser: 'chromium',
           }],
         },
+        retry: 2, // Retry twice on CI
         setupFiles: ['.storybook/vitest.setup.ts'],
       },
     }],


### PR DESCRIPTION
## Description

Ajoute une option de retry pour les tests Storybook afin d'améliorer leur fiabilité dans l'environnement CI.

## Changements

- Ajout de `retry: 2` dans la configuration Vitest pour le projet Storybook
- Les tests peuvent maintenant réessayer jusqu'à 2 fois en cas d'échec

## Motivation

Les tests Storybook peuvent parfois échouer de manière intermittente en CI, notamment à cause de :
- Variations dans les ressources disponibles
- Problèmes de timing dans le navigateur Playwright
- Latence réseau

L'option retry permet de réduire les faux négatifs tout en maintenant la qualité des tests.

## Type de changement

- [x] Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité)

closes #1237