### PR TITLE
fix(DsfrTag): corrige l'héritage des propriétés

### DIFF
--- a/src/components/DsfrCard/DsfrCard.vue
+++ b/src/components/DsfrCard/DsfrCard.vue
@@ -108,7 +108,10 @@ defineExpose({ goToTargetLink })
             {{ title }}
           </template>
         </component>
-        <p v-if="description" class="fr-card__desc">
+        <p
+          v-if="description"
+          class="fr-card__desc"
+        >
           {{ description }}
         </p>
         <div

--- a/src/components/DsfrTag/DsfrTags.types.ts
+++ b/src/components/DsfrTag/DsfrTags.types.ts
@@ -1,4 +1,5 @@
 import type VIcon from '../VIcon/VIcon.vue'
+import type { HTMLAttributes } from 'vue'
 
 export type DsfrTagProps<T = string> = {
   label?: string
@@ -21,4 +22,4 @@ export type DsfrTagProps<T = string> = {
 export type DsfrTagsProps<T = string> = {
   tags: DsfrTagProps<T>[]
   modelValue?: T[]
-}
+} & HTMLAttributes

--- a/src/components/DsfrTag/DsfrTags.vue
+++ b/src/components/DsfrTag/DsfrTags.vue
@@ -40,27 +40,12 @@ function onSelect ([value, selected]: [unknown, boolean]) {
     >
       <DsfrTag
         v-if="tag.selectable"
-        :label="tag.label"
-        :link="tag.link"
-        :tag-name="tag.tagName"
-        :icon="tag.icon"
-        :disabled="tag.disabled"
-        :small="tag.small"
-        :icon-only="tag.iconOnly"
-        :selectable="true"
-        :selected="modelValue?.includes(tag.value) || false"
-        :value="tag.value"
+        v-bind="tag"
         @select="onSelect($event as [unknown, boolean])"
       />
       <DsfrTag
         v-else
-        :label="tag.label"
-        :link="tag.link"
-        :tag-name="tag.tagName"
-        :icon="tag.icon"
-        :disabled="tag.disabled"
-        :small="tag.small"
-        :icon-only="tag.iconOnly"
+        v-bind="tag"
       />
     </li>
   </ul>


### PR DESCRIPTION
Fixes #1247

## Description du problème
Correction de l'héritage des propriétés sur le composant DsfrTag.

## Solution apportée
Correction du comportement hérité des attributs HTML pour assurer une propagation correcte des propriétés au composant enfant.