### PR TITLE
Feat(DsfrLanguageSelector): ✨ permet l'utilisation de la balise nav pour le sélecteur de langue

### DIFF
--- a/src/components/DsfrLanguageSelector/DsfrLanguageSelector.spec.ts
+++ b/src/components/DsfrLanguageSelector/DsfrLanguageSelector.spec.ts
@@ -15,9 +15,27 @@ describe('DsfrLanguageSelector', () => {
     })
     const defaultLanguage = getByText('FR - Français')
     const customLabel1 = getByText('EN - English')
+    const wrapper = document.querySelector('.fr-translate.fr-nav')
 
     // Then
     expect(defaultLanguage).toHaveAttribute('aria-current')
     expect(customLabel1).toHaveAttribute('lang')
+    expect(wrapper?.tagName).toBe('DIV')
+  })
+  it('should render a language selector with a nav wrapper tag (if requested)', () => {
+    // Given
+    const languages = [{ label: 'Français', codeIso: 'fr' }, { label: 'English', codeIso: 'en' }, { label: 'Deutsch', codeIso: 'de' }, { label: 'Nederlands', codeIso: 'nl' }]
+
+    // When
+    render(DsfrLanguageSelector, {
+      props: {
+        languages,
+        wrapperTag: 'nav',
+      },
+    })
+    const wrapper = document.querySelector('.fr-translate.fr-nav')
+
+    // Then
+    expect(wrapper?.tagName).toBe('NAV')
   })
 })

--- a/src/components/DsfrLanguageSelector/DsfrLanguageSelector.types.ts
+++ b/src/components/DsfrLanguageSelector/DsfrLanguageSelector.types.ts
@@ -8,4 +8,5 @@ export type DsfrLanguageSelectorProps = {
   languages: DsfrLanguageSelectorElement[]
   currentLanguage?: string
   title?: string
+  wrapperTag?: 'div' | 'nav'
 }

--- a/src/components/DsfrLanguageSelector/DsfrLanguageSelector.vue
+++ b/src/components/DsfrLanguageSelector/DsfrLanguageSelector.vue
@@ -13,6 +13,7 @@ const props = withDefaults(defineProps<DsfrLanguageSelectorProps>(), {
   languages: () => [],
   currentLanguage: 'fr',
   title: 'Sélectionner une langue',
+  wrapperTag: 'div',
 })
 
 const emit = defineEmits<{
@@ -47,7 +48,8 @@ watch(expanded, (newValue, oldValue) => {
 </script>
 
 <template>
-  <div
+  <component
+    :is="wrapperTag"
     class="fr-translate  fr-nav"
   >
     <div class="fr-nav__item">
@@ -85,5 +87,5 @@ watch(expanded, (newValue, oldValue) => {
         </ul>
       </div>
     </div>
-  </div>
+  </component>
 </template>


### PR DESCRIPTION
Permet l'utilisation de la balise nav au lieu de la balise div (par défaut) pour le sélecteur de langue conformément à la version 0.14.1 du DSFR (voir le [code](https://github.com/GouvernementFR/dsfr/pull/1229) - pas encore dans la doc DSFR)
closes #1226 