### PR TITLE
ci(publish): 🔒️ remplace le token npm permanent par OIDC avec provenance

### DIFF
--- a/.github/workflows/publish-release-beta.yml
+++ b/.github/workflows/publish-release-beta.yml
@@ -4,6 +4,12 @@ on:
     branches:
       - beta
 
+permissions:
+  contents: write
+  id-token: write
+  issues: write
+  pull-requests: write
+
 jobs:
   release:
     name: Release
@@ -27,5 +33,5 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_MININT_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
         run: pnpm run semantic-release

--- a/.github/workflows/publish-release-next.yml
+++ b/.github/workflows/publish-release-next.yml
@@ -4,6 +4,12 @@ on:
     branches:
       - next
 
+permissions:
+  contents: write
+  id-token: write
+  issues: write
+  pull-requests: write
+
 jobs:
   release:
     name: Release
@@ -27,5 +33,5 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_MININT_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
         run: pnpm run semantic-release

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,6 +4,12 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  id-token: write
+  issues: write
+  pull-requests: write
+
 jobs:
   release:
     name: Release
@@ -27,5 +33,5 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_MININT_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
         run: pnpm run semantic-release


### PR DESCRIPTION
## Summary

Fixes #1270

La politique de tokens npm a changé : les tokens permanents ne sont plus acceptés et doivent être renouvelés tous les 2 mois. Cette PR remplace l'authentification par token (`NPM_MININT_TOKEN`) par OIDC (OpenID Connect) entre GitHub Actions et npm sur les 3 workflows de publication (main, beta, next).

### Modifications apportées

- Ajout des permissions `contents: write` et `id-token: write`
- Remplacement de `NODE_AUTH_TOKEN` par `NPM_CONFIG_PROVENANCE: true`
- Les trusted publishers ont été configurés sur npmjs.com

Le secret `NPM_MININT_TOKEN` peut être supprimé des secrets GitHub après merge.

## Test plan

- [ ] Vérifier que la prochaine release sur `main` publie correctement sur npm
- [ ] Vérifier l'attestation de provenance sur le package publié (`npm audit signatures`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)