### PR TITLE
ci(publish): 🐛 retire registry-url de setup-node pour permettre l'OIDC

### DIFF
--- a/.github/workflows/publish-release-beta.yml
+++ b/.github/workflows/publish-release-beta.yml
@@ -23,7 +23,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 24
-          registry-url: 'https://registry.npmjs.org'
       - name: Upgrade npm
         run: npm install -g npm@11.7.0
       - name: Install pnpm

--- a/.github/workflows/publish-release-next.yml
+++ b/.github/workflows/publish-release-next.yml
@@ -23,7 +23,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 24
-          registry-url: 'https://registry.npmjs.org'
       - name: Upgrade npm
         run: npm install -g npm@11.7.0
       - name: Install pnpm

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -23,7 +23,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 24
-          registry-url: 'https://registry.npmjs.org'
       - name: Upgrade npm
         run: npm install -g npm@11.7.0
       - name: Install pnpm


### PR DESCRIPTION
## Summary

Fixes #1276

`actions/setup-node` avec `registry-url` crée un `~/.npmrc` contenant `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`. Comme `NODE_AUTH_TOKEN` n'est plus défini après la migration OIDC (#1270, #1273), `@semantic-release/npm` trouve un token vide et échoue à `verifyConditions` (401 sur `npm whoami`) au lieu de basculer sur l'authentification OIDC.

### Modification

Suppression de `registry-url` dans `actions/setup-node` sur les 3 workflows. Le registre est déjà configuré dans le `.npmrc` du projet (`@gouvminint:registry=https://registry.npmjs.org`).

## Test plan

- [ ] Vérifier que `verifyConditions` de `@semantic-release/npm` passe sans erreur
- [ ] Vérifier que la publication OIDC fonctionne de bout en bout

🤖 Generated with [Claude Code](https://claude.com/claude-code)