### PR TITLE
ci(publish): 🐛 ajoute le slash final au registre npm pour la détection OIDC

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
-@gouvminint:registry=https://registry.npmjs.org
+@gouvminint:registry=https://registry.npmjs.org/
 access=public
 


### PR DESCRIPTION
## Summary

Fixes #1279

`@semantic-release/npm` v13 compare strictement l'URL du registre avec sa constante `OFFICIAL_REGISTRY` (`https://registry.npmjs.org/` avec slash final). Le `.npmrc` avait `https://registry.npmjs.org` sans slash, donc la comparaison échouait et l'OIDC n'était jamais tenté.

### Modification

Ajout du `/` final dans `.npmrc` : `@gouvminint:registry=https://registry.npmjs.org/`

## Test plan

- [ ] Vérifier que `verifyConditions` de `@semantic-release/npm` détecte l'OIDC et passe
- [ ] Vérifier que la publication fonctionne de bout en bout

🤖 Generated with [Claude Code](https://claude.com/claude-code)