### PR TITLE
ci(publish): 🐛 ajoute publishConfig.registry pour la détection OIDC

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "type": "git",
     "url": "https://github.com/dnum-mi/vue-dsfr.git"
   },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
   "exports": {
     ".": {
       "import": {
@@ -44,10 +48,6 @@
   "engines": {
     "node": ">=22.0.0",
     "pnpm": ">=10.0.0"
-  },
-  "publishConfig": {
-    "@gouvminint:registry": "https://registry.npmjs.com",
-    "access": "public"
   },
   "scripts": {
     "check-exports": "node ./ci/check-exports.mjs",


### PR DESCRIPTION
## Summary

Fixes #1279

Malgré le slash final ajouté dans `.npmrc` (PR #1280), `@semantic-release/npm` v13 ne détectait toujours pas l'OIDC. La fonction `getRegistryUrl` de `registry-auth-token` peut normaliser l'URL différemment.

`publishConfig.registry` dans `package.json` est la **première** valeur vérifiée par `getRegistry` du plugin, avant le `.npmrc`. En la définissant explicitement à `https://registry.npmjs.org/` (avec slash final), on garantit la correspondance exacte avec `OFFICIAL_REGISTRY` et donc la détection OIDC.

### Modification

Ajout de `publishConfig` dans `package.json` :
```json
"publishConfig": {
  "registry": "https://registry.npmjs.org/",
  "access": "public"
}
```

## Test plan

- [ ] Vérifier que `verifyConditions` détecte l'OIDC (message "Verifying OIDC context for publishing from GitHub Actions" dans les logs)
- [ ] Vérifier que la publication fonctionne de bout en bout

🤖 Generated with [Claude Code](https://claude.com/claude-code)