### PR TITLE
ci(publish): 🔍 ajoute un step de debug pour diagnostiquer l'échec OIDC

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -31,6 +31,20 @@ jobs:
           version: 10.24.0
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - name: Debug OIDC context
+        run: |
+          node -e "
+            const pkg = JSON.parse(require('fs').readFileSync('package.json', 'utf8'));
+            console.log('publishConfig:', JSON.stringify(pkg.publishConfig));
+          "
+          pnpm exec node --input-type=module -e "
+            const { default: envCi } = await import('env-ci');
+            console.log('env-ci:', JSON.stringify(envCi()));
+          "
+          echo "ACTIONS_ID_TOKEN_REQUEST_URL set: ${ACTIONS_ID_TOKEN_REQUEST_URL:+yes}"
+          echo "GITHUB_ACTIONS: $GITHUB_ACTIONS"
+          cat .npmrc
+          pnpm list @semantic-release/npm --depth=0
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes #1284

Ajoute un step de debug temporaire dans `publish-release.yml` pour comprendre pourquoi l'OIDC n'est pas détecté. Vérifie :
- `publishConfig` du `package.json` déployé
- Résultat de `env-ci` (détection du provider CI)
- Présence de `ACTIONS_ID_TOKEN_REQUEST_URL`
- Contenu du `.npmrc`
- Version installée de `@semantic-release/npm`

Ce step sera supprimé une fois le diagnostic terminé.

## Test plan

- [ ] Merger dans develop puis main, lire les logs du step « Debug OIDC context »

🤖 Generated with [Claude Code](https://claude.com/claude-code)