### PR TITLE
fix(DsfrCard): 🐛 rend la prop description optionnelle

### DIFF
--- a/src/components/DsfrCard/DsfrCard.types.ts
+++ b/src/components/DsfrCard/DsfrCard.types.ts
@@ -12,7 +12,7 @@ export type DsfrCardProps = {
   link?: string | RouteLocationRaw
   title: string
   titleLinkAttrs?: Record<string, unknown>
-  description: string
+  description?: string
   size?: 'md' | 'medium' | 'large' | 'lg' | 'sm' | 'small' | undefined
   detail?: string
   detailIcon?: DsfrCardDetailProps['icon']

--- a/src/components/DsfrCard/DsfrCard.vue
+++ b/src/components/DsfrCard/DsfrCard.vue
@@ -14,6 +14,7 @@ const props = withDefaults(defineProps<DsfrCardProps>(), {
   titleLinkAttrs: () => ({}),
   imgSrc: undefined,
   link: undefined,
+  description: undefined,
   detail: undefined,
   detailIcon: undefined,
   endDetail: undefined,


### PR DESCRIPTION
## Summary

Fixes #1252

- Rend la prop `description` de `DsfrCard` optionnelle, conformément au [Système de Design de l'État](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/carte/design-de-la-carte) où la description n'est pas obligatoire
- Le template utilisait déjà un `v-if="description"`, donc aucun changement de comportement pour les usages existants

## Test plan

- [ ] Vérifier qu'une `DsfrCard` sans `description` s'affiche correctement (pas d'erreur TypeScript, pas de rendu parasite)
- [ ] Vérifier qu'une `DsfrCard` avec `description` fonctionne toujours comme avant

🤖 Generated with [Claude Code](https://claude.com/claude-code)