### PR TITLE
fix(DsfrHeaderMenuLinks): 🐛 remplace nav par div par défaut pour les accès rapides

### DIFF
--- a/src/components/DsfrHeader/DsfrHeaderMenuLinks.vue
+++ b/src/components/DsfrHeader/DsfrHeaderMenuLinks.vue
@@ -10,17 +10,19 @@ export type {
 withDefaults(defineProps<{
   links?: DsfrHeaderMenuLinkProps[]
   navAriaLabel?: string
+  wrapperTag?: 'div' | 'nav'
 }>(), {
   links: () => [],
   navAriaLabel: 'Menu secondaire',
+  wrapperTag: 'div',
 })
 
 const emit = defineEmits<{ linkClick: [event: MouseEvent] }>()
 </script>
 
 <template>
-  <nav
-    role="navigation"
+  <component
+    :is="wrapperTag"
     :aria-label="navAriaLabel"
   >
     <ul
@@ -36,5 +38,5 @@ const emit = defineEmits<{ linkClick: [event: MouseEvent] }>()
         />
       </li>
     </ul>
-  </nav>
+  </component>
 </template>


### PR DESCRIPTION
## Summary

fixes #1250

- Remplace la balise `<nav>` par un `<div>` par défaut dans `DsfrHeaderMenuLinks`, conformément au [code de l'en-tête du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/en-tete/code-de-l-en-tete) où le bloc d'accès rapides est un `div` avec un `ul`, pas un `nav`
- Ajoute une prop `wrapperTag` (`'div' | 'nav'`, défaut `'div'`) pour permettre aux utilisateurs qui ont besoin d'un `<nav>` de le conserver

## Test plan

- [x] Vérifier que le bloc d'accès rapides est bien un `<div>` par défaut
- [x] Vérifier qu'avec `wrapper-tag="nav"` le bloc est bien un `<nav>`
- [x] Vérifier la conformité RGAA 9.2 (les liens non-navigation ne sont plus dans un `<nav>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)