### PR TITLE
refactor(artwork): 🔒️ mutualise et sécurise le traitement des SVG data URI

### DIFF
--- a/src/utils/svg-data-uri-utils.spec.ts
+++ b/src/utils/svg-data-uri-utils.spec.ts
@@ -1,0 +1,30 @@
+import { sanitizeInlineSvgMarkupFromDataUri } from './svg-data-uri-utils'
+
+describe('svg-data-uri-utils', () => {
+  it('should sanitize dangerous SVG content', () => {
+    const unsafeSvg = '<svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)"><script>alert(1)</script><a href="javascript:alert(1)"><rect width="10" height="10" /></a></svg>'
+    const svgDataUri = `data:image/svg+xml,${encodeURIComponent(unsafeSvg)}`
+
+    const result = sanitizeInlineSvgMarkupFromDataUri(svgDataUri, 'suffix')
+
+    expect(result).toContain('<svg')
+    expect(result).not.toContain('onload=')
+    expect(result).not.toContain('<script')
+    expect(result).not.toContain('javascript:')
+  })
+
+  it('should rewrite DSFR artwork ids safely', () => {
+    const svgWithArtworkIds = '<svg xmlns="http://www.w3.org/2000/svg"><defs><g id="artwork-decorative" /></defs><use href="#artwork-decorative" /><path clip-path="url(#artwork-decorative)" /></svg>'
+    const svgDataUri = `data:image/svg+xml,${encodeURIComponent(svgWithArtworkIds)}`
+
+    const result = sanitizeInlineSvgMarkupFromDataUri(svgDataUri, 'abc')
+
+    expect(result).toContain('id="artwork-decorative-abc"')
+    expect(result).toContain('href="#artwork-decorative-abc"')
+    expect(result).toContain('url(#artwork-decorative-abc)')
+  })
+
+  it('should return empty string when data uri is invalid', () => {
+    expect(sanitizeInlineSvgMarkupFromDataUri('data:image/png;base64,abc', 'x')).toBe('')
+  })
+})

--- a/src/utils/svg-data-uri-utils.ts
+++ b/src/utils/svg-data-uri-utils.ts
@@ -1,0 +1,103 @@
+const SVG_DATA_URI_REGEX = /^data:image\/svg\+xml(?:;([^,]*))?,(.*)$/i
+const DANGEROUS_SVG_TAGS_SELECTOR = 'script,foreignObject,iframe,object,embed,audio,video,canvas'
+const DANGEROUS_ATTR_NAME_REGEX = /^on/i
+const ARTWORK_ID_REGEX = /^artwork-(?:decorative|minor|major)$/
+
+const decodeSvgDataUriPayload = (metadata: string, payload: string): string => {
+  const isBase64 = metadata
+    .toLowerCase()
+    .split(';')
+    .filter(Boolean)
+    .includes('base64')
+
+  return isBase64 ? globalThis.atob(payload) : decodeURIComponent(payload)
+}
+
+const sanitizeSvgElement = (svgElement: SVGElement): void => {
+  svgElement.querySelectorAll(DANGEROUS_SVG_TAGS_SELECTOR).forEach(node => node.remove())
+
+  const nodesToSanitize = [svgElement, ...Array.from(svgElement.querySelectorAll('*'))]
+  nodesToSanitize.forEach((node) => {
+    Array.from(node.attributes).forEach((attribute) => {
+      const name = attribute.name.toLowerCase()
+      const value = attribute.value.trim()
+
+      if (DANGEROUS_ATTR_NAME_REGEX.test(name) || name === 'src' || name === 'style') {
+        node.removeAttribute(attribute.name)
+        return
+      }
+
+      if (value.toLowerCase().includes('javascript:')) {
+        node.removeAttribute(attribute.name)
+        return
+      }
+
+      if ((name === 'href' || name === 'xlink:href') && !value.startsWith('#')) {
+        node.removeAttribute(attribute.name)
+      }
+    })
+  })
+}
+
+const rewriteArtworkIds = (svgElement: SVGElement, suffix: string): void => {
+  const idMap = new Map<string, string>()
+
+  svgElement.querySelectorAll('[id]').forEach((node) => {
+    const currentId = node.getAttribute('id')
+    if (!currentId || !ARTWORK_ID_REGEX.test(currentId)) {
+      return
+    }
+    const newId = `${currentId}-${suffix}`
+    idMap.set(currentId, newId)
+    node.setAttribute('id', newId)
+  })
+
+  if (idMap.size === 0) {
+    return
+  }
+
+  svgElement.querySelectorAll('*').forEach((node) => {
+    Array.from(node.attributes).forEach((attribute) => {
+      let nextValue = attribute.value
+      idMap.forEach((newId, currentId) => {
+        nextValue = nextValue
+          .replaceAll(`#${currentId}`, `#${newId}`)
+          .replaceAll(`url(#${currentId})`, `url(#${newId})`)
+      })
+      if (nextValue !== attribute.value) {
+        node.setAttribute(attribute.name, nextValue)
+      }
+    })
+  })
+}
+
+export const sanitizeInlineSvgMarkupFromDataUri = (svgDataUri: string | undefined, idSuffix: string): string => {
+  if (!svgDataUri || !globalThis.DOMParser || !globalThis.XMLSerializer) {
+    return ''
+  }
+
+  const match = svgDataUri.match(SVG_DATA_URI_REGEX)
+  if (!match) {
+    return ''
+  }
+
+  try {
+    const metadata = match[1] ?? ''
+    const payload = match[2] ?? ''
+    const decodedMarkup = decodeSvgDataUriPayload(metadata, payload)
+    const parser = new DOMParser()
+    const parsed = parser.parseFromString(decodedMarkup, 'image/svg+xml')
+    const svgElement = parsed.documentElement
+
+    if (svgElement.tagName.toLowerCase() !== 'svg') {
+      return ''
+    }
+
+    sanitizeSvgElement(svgElement as unknown as SVGElement)
+    rewriteArtworkIds(svgElement as unknown as SVGElement, idSuffix)
+
+    return new XMLSerializer().serializeToString(svgElement)
+  } catch {
+    return ''
+  }
+}


### PR DESCRIPTION
## Summary

fixes #1293

- Extrait la logique dupliquée de décodage/réécriture des SVG data URI de `DsfrRadioButton` et `DsfrTile` dans un utilitaire partagé `src/utils/svg-data-uri-utils.ts`
- Remplace le traitement par regex par un vrai parsing DOM (`DOMParser`) pour sanitiser le SVG :
  - Suppression des tags dangereux (`script`, `foreignObject`, `iframe`, etc.)
  - Suppression des attributs `on*`, `style`, `src`
  - Suppression des `href` contenant `javascript:`
- Réécriture des IDs artwork via le DOM au lieu de regex
- Ajout de tests unitaires (`svg-data-uri-utils.spec.ts`)

## Test plan

- [ ] Vérifier que les SVG data URI s'affichent correctement dans `DsfrRadioButton` et `DsfrTile`
- [ ] Vérifier que les SVG malveillants sont correctement sanitisés (pas de `<script>`, pas de `onload`, pas de `javascript:`)
- [ ] Vérifier que les IDs artwork sont toujours réécrits avec des suffixes uniques
- [ ] Vérifier que les tests unitaires passent

🤖 Generated with [Claude Code](https://claude.com/claude-code)