### PR TITLE
fix(DsfrHeaderMenuLinks): ♿ conditionne role et aria-label au tag nav

### DIFF
--- a/src/components/DsfrHeader/DsfrHeaderMenuLinks.vue
+++ b/src/components/DsfrHeader/DsfrHeaderMenuLinks.vue
@@ -23,7 +23,8 @@ const emit = defineEmits<{ linkClick: [event: MouseEvent] }>()
 <template>
   <component
     :is="wrapperTag"
-    :aria-label="navAriaLabel"
+    :role="wrapperTag === 'nav' ? 'navigation' : undefined"
+    :aria-label="wrapperTag === 'nav' ? navAriaLabel : undefined"
   >
     <ul
       class="fr-btns-group"


### PR DESCRIPTION
## Summary

fixes #1250

- Conditionne les attributs \`role="navigation"\` et \`aria-label\` au cas où \`wrapperTag="nav"\`
- Quand \`wrapperTag="div"\` (défaut), ces attributs ne sont plus rendus, évitant un landmark de navigation incorrect pour des liens qui ne constituent pas une zone de navigation (RGAA 9.2)

## Test plan

- [ ] Vérifier qu'avec le défaut (\`div\`), aucun \`role\` ni \`aria-label\` n'est présent dans le DOM
- [ ] Vérifier qu'avec \`wrapper-tag="nav"\`, \`role="navigation"\` et \`aria-label\` sont bien présents
- [ ] Vérifier l'accessibilité avec un lecteur d'écran

🤖 Generated with [Claude Code](https://claude.com/claude-code)