### PR TITLE
ci(publish): 🐛 corrige le format du changelog de semantic-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "chalk": "^5.6.2",
     "commander": "^13.1.0",
     "commitlint": "^19.8.1",
+    "conventional-changelog-conventionalcommits": "^9.1.0",
     "cross-env": "^10.1.0",
     "eslint": "^9.39.2",
     "eslint-plugin-import-x": "^4.16.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       commitlint:
         specifier: ^19.8.1
         version: 19.8.1(@types/node@24.10.13)(typescript@5.9.3)
+      conventional-changelog-conventionalcommits:
+        specifier: ^9.1.0
+        version: 9.1.0
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
@@ -3093,6 +3096,10 @@ packages:
   conventional-changelog-conventionalcommits@7.0.2:
     resolution: {integrity: sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==}
     engines: {node: '>=16'}
+
+  conventional-changelog-conventionalcommits@9.1.0:
+    resolution: {integrity: sha512-MnbEysR8wWa8dAEvbj5xcBgJKQlX/m0lhS8DsyAAWDHdfs2faDJxTgzRYlRYpXSe7UiKrIIlB4TrBKU9q9DgkA==}
+    engines: {node: '>=18'}
 
   conventional-changelog-writer@8.2.0:
     resolution: {integrity: sha512-Y2aW4596l9AEvFJRwFGJGiQjt2sBYTjPD18DdvxX9Vpz0Z7HQ+g1Z+6iYDAm1vR3QOJrDBkRHixHK/+FhkR6Pw==}
@@ -10369,6 +10376,10 @@ snapshots:
       compare-func: 2.0.0
 
   conventional-changelog-conventionalcommits@7.0.2:
+    dependencies:
+      compare-func: 2.0.0
+
+  conventional-changelog-conventionalcommits@9.1.0:
     dependencies:
       compare-func: 2.0.0
 


### PR DESCRIPTION
## Summary

fixes #1296

- Ajoute `conventional-changelog-conventionalcommits` v9 comme dépendance directe de développement
- Le preset `conventionalcommits` configuré dans `@semantic-release/release-notes-generator` était résolu via la dépendance transitive de `@commitlint/config-conventional` (v7), incompatible avec `conventional-changelog-writer@8` utilisé par semantic-release v25
- Cela produisait un changelog en liste plate, sans sections (features, bugs, etc.) ni filtrage des types cachés (`refactor`, `style`)

## Test plan

- [ ] Merger dans main et vérifier que la release générée a bien des sections séparées (✨ Nouvelles fonctionnalités, 🐛 Corrections de bugs, etc.)
- [ ] Vérifier que les types `refactor` et `style` sont bien masqués dans le changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)