### PR TITLE
fix(DsfrTooltip): 🐛 corrige le comportement d'affichage avec le clavier

### DIFF
--- a/src/components/DsfrTooltip/DsfrTooltip.vue
+++ b/src/components/DsfrTooltip/DsfrTooltip.vue
@@ -125,6 +125,14 @@ const onMouseLeave = () => {
   }
 }
 
+const onBlur = () => {
+  show.value = false
+}
+
+const onFocus = () => {
+  show.value = true
+}
+
 const onClick = () => {
   if (!props.onHover) {
     show.value = true
@@ -158,8 +166,8 @@ onUnmounted(() => {
     :type="onHover ? undefined : 'button'"
     @click="onClick()"
     @mouseleave="onMouseLeave()"
-    @focus="onMouseEnterHandler($event)"
-    @blur="onMouseLeave()"
+    @focus="onFocus()"
+    @blur="onBlur()"
   >
     <slot />
   </component>


### PR DESCRIPTION
- sur la prise de focus, afficher le message
- sur la prise de focus d'un autre élément, cacher le message

fixes #1306
