### PR TITLE
fix(DsfrSelect): 🐛 corrige l'accessibilité dans DsfrInputGroup

### DIFF
--- a/src/components/DsfrSelect/DsfrSelect.types.ts
+++ b/src/components/DsfrSelect/DsfrSelect.types.ts
@@ -14,4 +14,7 @@ export type DsfrSelectProps = {
   errorMessage?: string
   defaultUnselectedText?: string
   optionGroups?: ({ label: string, options: (DsfrSelectOption | { value: DsfrSelectOption, text: string, disabled?: boolean })[], disabled?: boolean })[]
+  isValid?: boolean
+  isInvalid?: boolean
+  descriptionId?: string
 }

--- a/src/components/DsfrSelect/DsfrSelect.vue
+++ b/src/components/DsfrSelect/DsfrSelect.vue
@@ -50,18 +50,17 @@ if (props.description) {
   )
 }
 
-const message = computed(() => {
-  return props.errorMessage || props.successMessage
-})
-const messageType = computed(() => {
-  return props.errorMessage ? 'error' : 'valid'
-})
+const hasError = computed(() => !!(props.errorMessage || props.isInvalid))
+const hasSuccess = computed(() => !!(props.successMessage || props.isValid) && !hasError.value)
+const message = computed(() =>
+  hasError.value ? props.errorMessage : hasSuccess.value ? props.successMessage : undefined,
+)
 </script>
 
 <template>
   <div
     class="fr-select-group"
-    :class="{ [`fr-select-group--${messageType}`]: message }"
+    :class="{ 'fr-select-group--error': hasError, 'fr-select-group--valid': hasSuccess }"
   >
     <label
       class="fr-label"
@@ -86,13 +85,14 @@ const messageType = computed(() => {
 
     <select
       :id="selectId"
-      :class="{ [`fr-select--${messageType}`]: message }"
+      :class="{ 'fr-select--error': hasError, 'fr-select--valid': hasSuccess }"
       class="fr-select"
       :name="name || selectId"
       :disabled="disabled"
       :aria-disabled="disabled"
       :required="required"
       v-bind="$attrs"
+      :aria-describedby="descriptionId || undefined"
       @change="$emit('update:modelValue', ($event.target as HTMLInputElement)?.value)"
     >
       <option
@@ -135,8 +135,8 @@ const messageType = computed(() => {
 
     <p
       v-if="message"
-      :id="`select-${messageType}-desc-${messageType}`"
-      :class="`fr-${messageType}-text`"
+      :id="`select-${hasError ? 'error' : 'valid'}-desc-${hasError ? 'error' : 'valid'}`"
+      :class="hasError ? 'fr-error-text' : 'fr-valid-text'"
     >
       {{ message }}
     </p>


### PR DESCRIPTION
Fixes #1312

## Problème

Quand `DsfrSelect` est utilisé dans le slot de `DsfrInputGroup` avec `v-slot="slotProps"` et `v-bind="slotProps"`, les props `isValid`, `isInvalid` et `descriptionId` n'étaient pas déclarées. Elles atterrissaient dans `\$attrs` (car `inheritAttrs: false`) et se retrouvaient sur le `<select>` en tant qu'attributs DOM lowercasés (`isvalid`, `isinvalid`, `descriptionid`). Résultat\u00a0: pas d'`aria-describedby`, état d'erreur non reflété.

`DsfrInput` fonctionnait car ces trois props y sont déclarées et utilisées explicitement.

## Solution

- Ajoute `isValid`, `isInvalid`, `descriptionId` à `DsfrSelectProps`
- `aria-describedby` branché sur `descriptionId` sur le `<select>`
- Remplace `messageType` par les computeds `hasError` et `hasSuccess` (qui combinent les props locales `errorMessage`/`successMessage` ET les nouvelles `isInvalid`/`isValid`)

## Plan de test

- [ ] `DsfrSelect` seul avec `errorMessage` → classe `fr-select-group--error` présente, message affiché
- [ ] `DsfrSelect` dans `DsfrInputGroup` avec `v-slot="slotProps"` + `v-bind="slotProps"` → `aria-describedby` présent, état d'erreur visible à l'inspecteur d'accessibilité
- [ ] Même test avec `validMessage` → `aria-describedby` présent, état valide visible
- [ ] Pas d'attributs parasites `isvalid`/`isinvalid`/`descriptionid` dans le DOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)