### PR TITLE
fix(DsfrModal): 🐛 n'émet plus close sur Echap quand la modale est fermée

### DIFF
--- a/src/components/DsfrModal/DsfrModal.vue
+++ b/src/components/DsfrModal/DsfrModal.vue
@@ -2,7 +2,7 @@
 import type { DsfrModalProps } from './DsfrModal.types'
 
 import { FocusTrap } from 'focus-trap-vue'
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, useTemplateRef, watch } from 'vue'
 
 import DsfrButtonGroup from '../DsfrButton/DsfrButtonGroup.vue'
 import VIcon from '../VIcon/VIcon.vue'
@@ -41,6 +41,15 @@ const closeIfEscape = ($event: KeyboardEvent) => {
     return
   }
   if ($event.key === 'Escape') {
+    close()
+  }
+}
+
+function closeIfOutside (event: MouseEvent) {
+  if (props.isAlert) {
+    return
+  }
+  if (!(event.target as HTMLElement).closest('.fr-modal__body')) {
     close()
   }
 }
@@ -118,6 +127,7 @@ const iconProps = computed(() => dsfrIcon.value
       class="fr-modal"
       :class="{ 'fr-modal--opened': opened }"
       :open="opened"
+      @click="closeIfOutside"
     >
       <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">

--- a/src/components/DsfrModal/DsfrModal.vue
+++ b/src/components/DsfrModal/DsfrModal.vue
@@ -2,7 +2,7 @@
 import type { DsfrModalProps } from './DsfrModal.types'
 
 import { FocusTrap } from 'focus-trap-vue'
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from 'vue'
 
 import DsfrButtonGroup from '../DsfrButton/DsfrButtonGroup.vue'
 import VIcon from '../VIcon/VIcon.vue'
@@ -37,6 +37,9 @@ defineSlots<{
 }>()
 
 const closeIfEscape = ($event: KeyboardEvent) => {
+  if (!props.opened) {
+    return
+  }
   if ($event.key === 'Escape') {
     close()
   }
@@ -46,8 +49,8 @@ const role = computed(() => {
   return props.isAlert ? 'alertdialog' : 'dialog'
 })
 
-const closeBtn = ref<HTMLButtonElement | null>(null)
-const modal = ref()
+const closeBtn = useTemplateRef('closeBtn')
+const modal = useTemplateRef('modal')
 watch(() => props.opened, (newValue) => {
   if (newValue) {
     modal.value?.showModal()

--- a/src/components/DsfrModal/docs-demo/DsfrModalDemo.vue
+++ b/src/components/DsfrModal/docs-demo/DsfrModalDemo.vue
@@ -17,10 +17,10 @@ const icon = ref('ri-checkbox-circle-line')
       Ouvrir la modale
     </DsfrButton>
     <DsfrModal
-      v-model:opened="opened"
-      :title="title"
-      :icon="icon"
-      :is-alert="isAlert"
+      :opened
+      :title
+      :icon
+      :is-alert
       @close="opened = false"
     >
       <template #default>

--- a/src/components/DsfrModal/docs-demo/DsfrModalDemoActions.vue
+++ b/src/components/DsfrModal/docs-demo/DsfrModalDemoActions.vue
@@ -52,11 +52,11 @@ const actions: DsfrButtonProps[] = [
       Veut des patates : {{ validated ? 'Oui' : 'Non' }}
     </p>
     <DsfrModal
-      v-model:opened="opened"
-      :title="title"
-      :icon="icon"
-      :is-alert="isAlert"
-      :actions="actions"
+      :opened
+      :title
+      :icon
+      :is-alert
+      :actions
       @close="opened = false"
     >
       <template #default>


### PR DESCRIPTION
Fixes #1303
Fixes #1311

## Problèmes

**#1303** — L'événement `close` était émis à chaque appui sur Échap, même quand la modale était fermée. Tout listener `@close` se déclenchait donc sans interaction visible.

**#1311** — Aucun mécanisme ne fermait la modale au clic sur la zone grise extérieure.

## Solutions

**#1303** — Guard `if (!props.opened) { return }` en tête de `closeIfEscape`.

**#1311** — Ajout de `closeIfOutside` sur `@click` du `<dialog>` : utilise `Element.closest('.fr-modal__body')` pour détecter si le clic est en dehors du contenu. Ne ferme pas si `isAlert: true` (un `alertdialog` exige une action explicite).

## Améliorations associées

- `useTemplateRef` pour `closeBtn` et `modal` (API Vue 3.5+)
- Démos corrigées : `v-model:opened` remplacé par `:opened` + `@close="opened = false"`

## Plan de test

- [x] Appuyer sur Échap sans modale ouverte → `@close` ne se déclenche pas
- [x] Ouvrir la modale puis appuyer sur Échap → fermeture
- [ ] Cliquer en dehors de la boîte blanche → fermeture
- [ ] Cliquer à l'intérieur de la boîte → pas de fermeture
- [ ] `isAlert: true` + clic extérieur → pas de fermeture

🤖 Generated with [Claude Code](https://claude.com/claude-code)