### PR TITLE
fix(DsfrSelect): 🐛 fusionne aria-describedby de $attrs avec descriptionId

### DIFF
--- a/src/components/DsfrSelect/DsfrSelect.vue
+++ b/src/components/DsfrSelect/DsfrSelect.vue
@@ -92,7 +92,7 @@ const message = computed(() =>
       :aria-disabled="disabled"
       :required="required"
       v-bind="$attrs"
-      :aria-describedby="descriptionId || undefined"
+      :aria-describedby="[($attrs['aria-describedby'] as string), descriptionId].filter(Boolean).join(' ') || undefined"
       @change="$emit('update:modelValue', ($event.target as HTMLInputElement)?.value)"
     >
       <option


### PR DESCRIPTION
Fixes #1324

## Problème

Placer `:aria-describedby` **après** `v-bind="$attrs"` écrasait l'attribut éponyme passé par les consommateurs du composant, cassant le câblage d'accessibilité dans les formulaires qui lient du texte d'aide ou d'erreur externe par ID.

## Solution

Les deux valeurs sont désormais combinées (séparées par un espace), conformément aux recommandations ARIA :

```html
:aria-describedby="[($attrs['aria-describedby'] as string), descriptionId].filter(Boolean).join(' ') || undefined"
```

- si le consommateur fournit un `aria-describedby` **et** que `descriptionId` existe → les deux IDs sont présents
- si seulement l'un des deux est défini → seul celui-là est utilisé
- si aucun → l'attribut n'est pas rendu (`undefined`)