### PR TITLE
chore(config): 🔧 aligne la config TS et VS Code sur TypeScript 6

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -69,5 +69,6 @@
     "gql",
     "graphql",
     "astro"
-  ]
+  ],
+  "js/ts.tsdk.path": "node_modules/typescript/lib"
 }

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "composite": true,
     "lib": [
-      "ES2023",
+      "ES2025",
       "DOM",
       "DOM.Iterable"
     ],


### PR DESCRIPTION
Fixes #1328

## Modifications

**`tsconfig.app.json`**
- `lib` : `ES2023` → `ES2025` — cohérent avec TypeScript 6 et les nouvelles APIs JS disponibles

**`.vscode/settings.json`**
- Ajoute `js/ts.tsdk.path: "node_modules/typescript/lib"` — VS Code utilise désormais le TypeScript local du projet (TS 6) au lieu de sa version embarquée