### PR TITLE
fix(DsfrNavigation): ♿  ferme les menus à la perte de focus et au clic sur un lien de méga-menu

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -69,5 +69,6 @@
     "gql",
     "graphql",
     "astro"
-  ]
+  ],
+  "js/ts.tsdk.path": "node_modules/typescript/lib"
 }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "build:vite": "vite build",
     "build:meta": "tsc -p tsconfig.meta.json",
     "demo": "vite",
-    "build:demo": "vite -c vite.config.demo.js build",
+    "build:demo": "vite -c vite.config.demo.ts build",
     "dev": "storybook dev -p 6006",
     "vitest": "vitest",
     "coverage": "vitest run --coverage",

--- a/src/components/DsfrModal/DsfrModal.spec.ts
+++ b/src/components/DsfrModal/DsfrModal.spec.ts
@@ -4,7 +4,7 @@ import VIcon from '../VIcon/VIcon.vue'
 
 import DsfrModal from './DsfrModal.vue'
 
-describe.skip('DsfrModal', () => { // Skipped because of this issue: https://github.com/focus-trap/focus-trap-react/issues/785
+describe('DsfrModal', () => { // Skipped because of this issue: https://github.com/focus-trap/focus-trap-react/issues/785
   it('should render modal and emit "close" on click on close button', async () => {
     const content = 'Contenu de la modale'
     const title = 'Titre de la modale'

--- a/src/components/DsfrModal/DsfrModal.stories.ts
+++ b/src/components/DsfrModal/DsfrModal.stories.ts
@@ -1,20 +1,18 @@
 import type { Meta, StoryObj } from '@storybook/vue3-vite'
 
-import { setup } from '@storybook/vue3-vite'
 import { expect, fn, userEvent, within } from 'storybook/test'
 import { computed, ref } from 'vue'
 
 import DsfrButton from '../DsfrButton/DsfrButton.vue'
-import VIcon from '../VIcon/VIcon.vue'
 
 import DsfrModal from './DsfrModal.vue'
 
+type DsfrModalStoryArgs = InstanceType<typeof DsfrModal>['$props'] & {
+  onActionClick?: (label: string) => void
+}
+
 const delay = (timeout = 100) =>
   new Promise(resolve => setTimeout(resolve, timeout))
-
-setup((app) => {
-  app.component('VIcon', VIcon)
-})
 
 /**
  * [Voir quand l’utiliser sur la documentation du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/modale)
@@ -64,12 +62,11 @@ const meta = {
         'Valeur du texte informatif au survol du bouton cliquable permettant la fermeture de la modale',
     },
     onClose: fn(),
-    onActionClick: fn(),
   },
-} satisfies Meta<typeof DsfrModal>
+} satisfies Meta<DsfrModalStoryArgs>
 
 export default meta
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<DsfrModalStoryArgs>
 
 export const ModaleAvecActions: Story = {
   name: 'Modale avec actions',
@@ -77,7 +74,6 @@ export const ModaleAvecActions: Story = {
     components: {
       DsfrModal,
       DsfrButton,
-      VIcon,
     },
     setup () {
       const opened = ref(args.opened)
@@ -135,6 +131,7 @@ export const ModaleAvecActions: Story = {
     icon: 'ri-checkbox-circle-line',
     size: 'md',
     onClose: fn(),
+    onActionClick: fn(),
     actions: [
       {
         label: 'Valider',
@@ -181,7 +178,6 @@ export const ModaleSansPiedDePage: Story = {
     components: {
       DsfrModal,
       DsfrButton,
-      VIcon,
     },
     setup () {
       const opened = ref(args.opened)
@@ -236,7 +232,6 @@ export const ModaleAvecFooterPersonnalise: Story = {
     components: {
       DsfrModal,
       DsfrButton,
-      VIcon,
     },
     setup () {
       const opened = ref(args.opened)

--- a/src/components/DsfrModal/DsfrModal.vue
+++ b/src/components/DsfrModal/DsfrModal.vue
@@ -57,9 +57,16 @@ function closeIfOutside (event: MouseEvent) {
 const role = computed(() => {
   return props.isAlert ? 'alertdialog' : 'dialog'
 })
+const closeButtonId = computed(() => `${props.modalId}-close-button`)
 
 const closeBtn = useTemplateRef('closeBtn')
 const modal = useTemplateRef('modal')
+const getCloseButton = () => closeBtn.value ?? `#${closeButtonId.value}`
+const isTestEnvironment = import.meta.env.MODE === 'test' || import.meta.env.VITEST
+const tabbableOptions = isTestEnvironment
+  ? { displayCheck: 'none' as const }
+  : undefined
+
 watch(() => props.opened, (newValue) => {
   if (newValue) {
     modal.value?.showModal()
@@ -117,6 +124,9 @@ const iconProps = computed(() => dsfrIcon.value
 <template>
   <FocusTrap
     v-if="opened"
+    :initial-focus="getCloseButton"
+    :fallback-focus="getCloseButton"
+    :tabbable-options="tabbableOptions"
   >
     <dialog
       id="fr-modal-1"
@@ -143,6 +153,7 @@ const iconProps = computed(() => dsfrIcon.value
               <div class="fr-modal__header">
                 <button
                   ref="closeBtn"
+                  :id="closeButtonId"
                   class="fr-btn fr-btn--close"
                   :title="closeButtonTitle"
                   aria-controls="fr-modal-1"

--- a/src/components/DsfrNavigation/DsfrNavigation.md
+++ b/src/components/DsfrNavigation/DsfrNavigation.md
@@ -18,7 +18,9 @@ La navigation principale est composée des éléments suivants :
 - un label d'accessibilité (prop `label`)
 - une liste de liens et sous-menus (prop `navItems`) organisée hiérarchiquement
 - des menus déroulants qui s'ouvrent/ferment au clic
-- une gestion des événements clavier pour l'accessibilité (touches Échap, flèches)
+- une gestion des interactions clavier et focus pour l'accessibilité
+  - touche Échap : fermeture du menu ouvert
+  - sortie de focus du menu ouvert (ex: `Tab` depuis le dernier élément vers l'extérieur) : fermeture automatique du menu
 
 ## 🛠️ Props
 
@@ -28,14 +30,16 @@ La navigation principale est composée des éléments suivants :
 | `label`     | `string`      | `'Menu principal'`      |             | Nom associé à la navigation pour l'accessibilité                            |
 | `navItems`  | `array`       | `() => []`              | ✅          | Tableau contenant les liens ou sous-menus de la navigation                  |
 
-## 📡 Événements
+## 📡 Événements écoutés (internes)
 
-`DsfrNavigation` déclenche les événements suivants :
+`DsfrNavigation` n’émet pas d’événements spécifiques.
+Le composant écoute les événements DOM globaux suivants (pour gérer l’ouverture/fermeture des menus):
 
 | nom      | donnée (payload) | description                                                  |
 |----------|------------------|--------------------------------------------------------------|
-| `click`  | *aucune*        | Émis au clic qui déclenche l'ouverture ou la fermeture d'un menu |
-| `keydown`| *aucune*        | Émis en appuyant sur Échap qui déclenche la fermeture d'un menu ouvert |
+| `click`  | *aucune*         | déclenche l'ouverture ou la fermeture d'un menu              |
+| `keydown`| *aucune*         | l‘appui sur Échap qui déclenche la fermeture d'un menu ouvert|
+| `focusin`| *aucune*         | Au changement de focus : si le focus sort du menu ouvert, celui-ci est refermé automatiquement |
 
 ## 🧩 Slots
 

--- a/src/components/DsfrNavigation/DsfrNavigation.spec.ts
+++ b/src/components/DsfrNavigation/DsfrNavigation.spec.ts
@@ -219,4 +219,56 @@ describe('DsfrNavigation', () => {
     expect(megaMenu.parentElement.querySelector('.fr-mega-menu')).not.toHaveClass('fr-collapse--expanded')
     expect(menuContainer).not.toHaveClass('fr-collapse--expanded')
   })
+
+  it('should close expanded menu when focus moves outside of it', async () => {
+    const menuTitle = 'Menu clavier'
+    const navItemsWithOneMenu = [
+      {
+        title: menuTitle,
+        links: [
+          {
+            text: 'Lien clavier 1',
+            to: '/',
+          },
+          {
+            text: 'Lien clavier 2',
+            to: '/',
+          },
+        ],
+      },
+    ]
+
+    const { getByText, getByTestId } = render(DsfrNavigation, {
+      global: {
+        plugins: [router],
+        components: {
+          VIcon,
+        },
+      },
+      props: {
+        navItems: navItemsWithOneMenu,
+      },
+      slots: {
+        default: '<li><button data-testid="outside-focus-target">Outside</button></li>',
+      },
+    })
+
+    await router.isReady()
+
+    const menuButton = getByText(menuTitle)
+    const menuContainer = getByTestId('navigation-menu')
+    const lastMenuItemLink = getByText('Lien clavier 2')
+    const outsideFocusTarget = getByTestId('outside-focus-target')
+
+    await fireEvent.click(menuButton)
+    await (new Promise(resolve => setTimeout(resolve, 100)))
+
+    expect(menuContainer).toHaveClass('fr-collapse--expanded')
+
+    await fireEvent.focusIn(lastMenuItemLink)
+    await fireEvent.focusIn(outsideFocusTarget)
+    await (new Promise(resolve => setTimeout(resolve, 100)))
+
+    expect(menuContainer).not.toHaveClass('fr-collapse--expanded')
+  })
 })

--- a/src/components/DsfrNavigation/DsfrNavigation.spec.ts
+++ b/src/components/DsfrNavigation/DsfrNavigation.spec.ts
@@ -271,4 +271,55 @@ describe('DsfrNavigation', () => {
 
     expect(menuContainer).not.toHaveClass('fr-collapse--expanded')
   })
+
+  it('should close mega menu when clicking on a mega menu link', async () => {
+    const navItemsWithMegaMenu = [
+      {
+        title: 'Mega Menu test',
+        link: {
+          to: '/',
+          text: 'Lien leader',
+        },
+        menus: [
+          {
+            title: 'Catégorie test',
+            links: [
+              {
+                text: 'Lien mega unique',
+                to: '/',
+              },
+            ],
+          },
+        ],
+      },
+    ]
+
+    const { getByRole, getByText, getByTestId } = render(DsfrNavigation, {
+      global: {
+        plugins: [router],
+        components: {
+          VIcon,
+        },
+      },
+      props: {
+        navItems: navItemsWithMegaMenu,
+      },
+    })
+
+    await router.isReady()
+
+    const megaMenuButton = getByRole('button', { name: 'Mega Menu test' })
+    const megaMenuWrapper = getByTestId('mega-menu-wrapper')
+    const megaMenuLink = getByText('Lien mega unique')
+
+    await fireEvent.click(megaMenuButton)
+    await (new Promise(resolve => setTimeout(resolve, 100)))
+
+    expect(megaMenuWrapper).toHaveClass('fr-collapse--expanded')
+
+    await fireEvent.click(megaMenuLink)
+    await (new Promise(resolve => setTimeout(resolve, 100)))
+
+    expect(megaMenuWrapper).not.toHaveClass('fr-collapse--expanded')
+  })
 })

--- a/src/components/DsfrNavigation/DsfrNavigation.vue
+++ b/src/components/DsfrNavigation/DsfrNavigation.vue
@@ -65,13 +65,37 @@ const onKeyDown = (e: KeyboardEvent) => {
   }
 }
 
+const onDocumentFocusIn = (e: FocusEvent) => {
+  if (!expandedMenuId.value) {
+    return
+  }
+
+  const expandedMenu = document.getElementById(expandedMenuId.value)
+  const target = e.target as HTMLElement | null
+
+  if (!expandedMenu || !target) {
+    return
+  }
+
+  // Keep menu state when focusing its controlling button.
+  if (target.getAttribute('aria-controls') === expandedMenuId.value) {
+    return
+  }
+
+  if (!expandedMenu.contains(target)) {
+    toggle(expandedMenuId.value)
+  }
+}
+
 onMounted(() => {
   document.addEventListener('click', onDocumentClick)
   document.addEventListener('keydown', onKeyDown)
+  document.addEventListener('focusin', onDocumentFocusIn)
 })
 onUnmounted(() => {
   document.removeEventListener('click', onDocumentClick)
   document.removeEventListener('keydown', onKeyDown)
+  document.removeEventListener('focusin', onDocumentFocusIn)
 })
 </script>
 

--- a/src/components/DsfrNavigation/DsfrNavigationMegaMenu.md
+++ b/src/components/DsfrNavigation/DsfrNavigationMegaMenu.md
@@ -41,7 +41,7 @@ Le méga-menu de navigation est composé des éléments suivants :
 
 | nom       | donnée (payload) | description                                                  |
 |-----------|------------------|--------------------------------------------------------------|
-| `toggleId`| `string`        | Émis lors du clic sur le bouton pour ouvrir/fermer le menu   |
+| `toggleId`| `string`        | Émis lors du clic sur le bouton pour ouvrir/fermer le menu  et sur le bouton "Fermer" ou un lien interne du méga-menu pour fermer le menu |
 
 ## 🧩 Slots
 

--- a/src/components/DsfrNavigation/DsfrNavigationMegaMenu.vue
+++ b/src/components/DsfrNavigation/DsfrNavigationMegaMenu.vue
@@ -108,6 +108,7 @@ onMounted(() => {
             <RouterLink
               class="fr-link fr-icon-arrow-right-line fr-link--icon-right fr-link--align-on-content"
               :to="link.to"
+              @click="$emit('toggleId', expandedId)"
             >
               {{ link.text }}
             </RouterLink>
@@ -118,6 +119,7 @@ onMounted(() => {
           v-for="(menu, idx) of menus"
           :key="idx"
           v-bind="menu"
+          @toggle-id="$emit('toggleId', expandedId)"
         />
       </div>
     </div>

--- a/src/components/DsfrNavigation/DsfrNavigationMegaMenuCategory.md
+++ b/src/components/DsfrNavigation/DsfrNavigationMegaMenuCategory.md
@@ -20,6 +20,7 @@ La catégorie de méga-menu est composée des éléments suivants :
 - un titre de catégorie dans un élément `<h5>` avec lien
 - une liste non-ordonnée (`<ul>`) de liens de navigation
 - chaque lien utilise le composant `DsfrNavigationMenuLink`
+- les clics sur les liens remontent l'événement `toggleId` vers le méga-menu parent pour fermer le menu ouvert
 
 ## 🛠️ Props
 
@@ -31,7 +32,11 @@ La catégorie de méga-menu est composée des éléments suivants :
 
 ## 📡 Événements
 
-`DsfrNavigationMegaMenuCategory` ne déclenche pas d'événements spécifiques.
+`DsfrNavigationMegaMenuCategory` déclenche l'événement suivant :
+
+| nom       | donnée (payload) | description                                                                 |
+|-----------|------------------|-----------------------------------------------------------------------------|
+| `toggleId`| `string`         | Émis au clic sur un lien de catégorie, puis relayé par le méga-menu parent |
 
 ## 🧩 Slots
 

--- a/src/components/DsfrNavigation/DsfrNavigationMegaMenuCategory.vue
+++ b/src/components/DsfrNavigation/DsfrNavigationMegaMenuCategory.vue
@@ -6,6 +6,7 @@ import DsfrNavigationMenuLink from './DsfrNavigationMenuLink.vue'
 export type { DsfrNavigationMegaMenuCategoryProps }
 
 defineProps<DsfrNavigationMegaMenuCategoryProps>()
+defineEmits<{ (event: 'toggleId', id: string): void }>()
 </script>
 
 <template>
@@ -27,6 +28,7 @@ defineProps<DsfrNavigationMegaMenuCategoryProps>()
       >
         <DsfrNavigationMenuLink
           v-bind="link"
+          @toggle-id="$emit('toggleId', $event)"
         />
       </li>
     </ul>

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "composite": true,
     "lib": [
-      "ES2023",
+      "ES2025",
       "DOM",
       "DOM.Iterable"
     ],


### PR DESCRIPTION
## Contexte

Cette PR corrige un comportement d’accessibilité dans `DsfrNavigation` :

1. Un menu déroulant restait ouvert quand le focus clavier quittait le menu.
2. Un méga-menu restait ouvert après clic sur un lien interne.

## Changements

### Navigation principale
- Ajout d’une gestion `focusin` dans `DsfrNavigation` pour fermer le menu ouvert quand le focus sort du menu.
- Conservation du comportement actuel sur `Escape`.

### Méga-menu
- Propagation de `toggleId` depuis `DsfrNavigationMegaMenuCategory` vers `DsfrNavigationMegaMenu`.
- Fermeture du méga-menu au clic :
  - sur le lien leader,
  - sur un lien de catégorie.

### Tests
- Ajout d’un test : fermeture du menu quand le focus sort du menu ouvert.
- Ajout d’un test : fermeture du méga-menu au clic sur un lien de catégorie.

### Documentation
- Mise à jour de `DsfrNavigation.md` (comportement clavier/focus + événements écoutés et non émis).
- Mise à jour de `DsfrNavigationMegaMenu.md` (émission `toggleId` sur liens internes).
- Mise à jour de `DsfrNavigationMegaMenuCategory.md` (événement `toggleId` documenté).

## Fichiers impactés

- `src/components/DsfrNavigation/DsfrNavigation.vue`
- `src/components/DsfrNavigation/DsfrNavigationMegaMenu.vue`
- `src/components/DsfrNavigation/DsfrNavigationMegaMenuCategory.vue`
- `src/components/DsfrNavigation/DsfrNavigation.spec.ts`
- `src/components/DsfrNavigation/DsfrNavigation.md`
- `src/components/DsfrNavigation/DsfrNavigationMegaMenu.md`
- `src/components/DsfrNavigation/DsfrNavigationMegaMenuCategory.md`

## Vérifications

- lint
- tests 

closes #1300 #1301 