### PR TITLE
fix(DsfrNavigation): ♿ ferme les menus à la perte de focus et au clic sur un lien de méga-menu

### DIFF
--- a/src/components/DsfrNavigation/DsfrNavigation.md
+++ b/src/components/DsfrNavigation/DsfrNavigation.md
@@ -18,7 +18,9 @@ La navigation principale est composée des éléments suivants :
 - un label d'accessibilité (prop `label`)
 - une liste de liens et sous-menus (prop `navItems`) organisée hiérarchiquement
 - des menus déroulants qui s'ouvrent/ferment au clic
-- une gestion des événements clavier pour l'accessibilité (touches Échap, flèches)
+- une gestion des interactions clavier et focus pour l'accessibilité
+  - touche Échap : fermeture du menu ouvert
+  - sortie de focus du menu ouvert (ex: `Tab` depuis le dernier élément vers l'extérieur) : fermeture automatique du menu
 
 ## 🛠️ Props
 
@@ -28,14 +30,16 @@ La navigation principale est composée des éléments suivants :
 | `label`     | `string`      | `'Menu principal'`      |             | Nom associé à la navigation pour l'accessibilité                            |
 | `navItems`  | `array`       | `() => []`              | ✅          | Tableau contenant les liens ou sous-menus de la navigation                  |
 
-## 📡 Événements
+## 📡 Événements écoutés (internes)
 
-`DsfrNavigation` déclenche les événements suivants :
+`DsfrNavigation` n’émet pas d’événements spécifiques.
+Le composant écoute les événements DOM globaux suivants (pour gérer l’ouverture/fermeture des menus):
 
 | nom      | donnée (payload) | description                                                  |
 |----------|------------------|--------------------------------------------------------------|
-| `click`  | *aucune*        | Émis au clic qui déclenche l'ouverture ou la fermeture d'un menu |
-| `keydown`| *aucune*        | Émis en appuyant sur Échap qui déclenche la fermeture d'un menu ouvert |
+| `click`  | *aucune*         | déclenche l'ouverture ou la fermeture d'un menu              |
+| `keydown`| *aucune*         | l‘appui sur Échap qui déclenche la fermeture d'un menu ouvert|
+| `focusin`| *aucune*         | Au changement de focus : si le focus sort du menu ouvert, celui-ci est refermé automatiquement |
 
 ## 🧩 Slots
 

--- a/src/components/DsfrNavigation/DsfrNavigation.spec.ts
+++ b/src/components/DsfrNavigation/DsfrNavigation.spec.ts
@@ -219,4 +219,56 @@ describe('DsfrNavigation', () => {
     expect(megaMenu.parentElement.querySelector('.fr-mega-menu')).not.toHaveClass('fr-collapse--expanded')
     expect(menuContainer).not.toHaveClass('fr-collapse--expanded')
   })
+
+  it('should close expanded menu when focus moves outside of it', async () => {
+    const menuTitle = 'Menu clavier'
+    const navItemsWithOneMenu = [
+      {
+        title: menuTitle,
+        links: [
+          {
+            text: 'Lien clavier 1',
+            to: '/',
+          },
+          {
+            text: 'Lien clavier 2',
+            to: '/',
+          },
+        ],
+      },
+    ]
+
+    const { getByText, getByTestId } = render(DsfrNavigation, {
+      global: {
+        plugins: [router],
+        components: {
+          VIcon,
+        },
+      },
+      props: {
+        navItems: navItemsWithOneMenu,
+      },
+      slots: {
+        default: '<li><button data-testid="outside-focus-target">Outside</button></li>',
+      },
+    })
+
+    await router.isReady()
+
+    const menuButton = getByText(menuTitle)
+    const menuContainer = getByTestId('navigation-menu')
+    const lastMenuItemLink = getByText('Lien clavier 2')
+    const outsideFocusTarget = getByTestId('outside-focus-target')
+
+    await fireEvent.click(menuButton)
+    await (new Promise(resolve => setTimeout(resolve, 100)))
+
+    expect(menuContainer).toHaveClass('fr-collapse--expanded')
+
+    await fireEvent.focusIn(lastMenuItemLink)
+    await fireEvent.focusIn(outsideFocusTarget)
+    await (new Promise(resolve => setTimeout(resolve, 100)))
+
+    expect(menuContainer).not.toHaveClass('fr-collapse--expanded')
+  })
 })

--- a/src/components/DsfrNavigation/DsfrNavigation.spec.ts
+++ b/src/components/DsfrNavigation/DsfrNavigation.spec.ts
@@ -271,4 +271,55 @@ describe('DsfrNavigation', () => {
 
     expect(menuContainer).not.toHaveClass('fr-collapse--expanded')
   })
+
+  it('should close mega menu when clicking on a mega menu link', async () => {
+    const navItemsWithMegaMenu = [
+      {
+        title: 'Mega Menu test',
+        link: {
+          to: '/',
+          text: 'Lien leader',
+        },
+        menus: [
+          {
+            title: 'Catégorie test',
+            links: [
+              {
+                text: 'Lien mega unique',
+                to: '/',
+              },
+            ],
+          },
+        ],
+      },
+    ]
+
+    const { getByRole, getByText, getByTestId } = render(DsfrNavigation, {
+      global: {
+        plugins: [router],
+        components: {
+          VIcon,
+        },
+      },
+      props: {
+        navItems: navItemsWithMegaMenu,
+      },
+    })
+
+    await router.isReady()
+
+    const megaMenuButton = getByRole('button', { name: 'Mega Menu test' })
+    const megaMenuWrapper = getByTestId('mega-menu-wrapper')
+    const megaMenuLink = getByText('Lien mega unique')
+
+    await fireEvent.click(megaMenuButton)
+    await (new Promise(resolve => setTimeout(resolve, 100)))
+
+    expect(megaMenuWrapper).toHaveClass('fr-collapse--expanded')
+
+    await fireEvent.click(megaMenuLink)
+    await (new Promise(resolve => setTimeout(resolve, 100)))
+
+    expect(megaMenuWrapper).not.toHaveClass('fr-collapse--expanded')
+  })
 })

--- a/src/components/DsfrNavigation/DsfrNavigation.vue
+++ b/src/components/DsfrNavigation/DsfrNavigation.vue
@@ -65,13 +65,37 @@ const onKeyDown = (e: KeyboardEvent) => {
   }
 }
 
+const onDocumentFocusIn = (e: FocusEvent) => {
+  if (!expandedMenuId.value) {
+    return
+  }
+
+  const expandedMenu = document.getElementById(expandedMenuId.value)
+  const target = e.target as HTMLElement | null
+
+  if (!expandedMenu || !target) {
+    return
+  }
+
+  // Keep menu state when focusing its controlling button.
+  if (target.getAttribute('aria-controls') === expandedMenuId.value) {
+    return
+  }
+
+  if (!expandedMenu.contains(target)) {
+    toggle(expandedMenuId.value)
+  }
+}
+
 onMounted(() => {
   document.addEventListener('click', onDocumentClick)
   document.addEventListener('keydown', onKeyDown)
+  document.addEventListener('focusin', onDocumentFocusIn)
 })
 onUnmounted(() => {
   document.removeEventListener('click', onDocumentClick)
   document.removeEventListener('keydown', onKeyDown)
+  document.removeEventListener('focusin', onDocumentFocusIn)
 })
 </script>
 

--- a/src/components/DsfrNavigation/DsfrNavigationMegaMenu.md
+++ b/src/components/DsfrNavigation/DsfrNavigationMegaMenu.md
@@ -41,7 +41,7 @@ Le méga-menu de navigation est composé des éléments suivants :
 
 | nom       | donnée (payload) | description                                                  |
 |-----------|------------------|--------------------------------------------------------------|
-| `toggleId`| `string`        | Émis lors du clic sur le bouton pour ouvrir/fermer le menu   |
+| `toggleId`| `string`        | Émis lors du clic sur le bouton pour ouvrir/fermer le menu  et sur le bouton "Fermer" ou un lien interne du méga-menu pour fermer le menu |
 
 ## 🧩 Slots
 

--- a/src/components/DsfrNavigation/DsfrNavigationMegaMenu.vue
+++ b/src/components/DsfrNavigation/DsfrNavigationMegaMenu.vue
@@ -108,6 +108,7 @@ onMounted(() => {
             <RouterLink
               class="fr-link fr-icon-arrow-right-line fr-link--icon-right fr-link--align-on-content"
               :to="link.to"
+              @click="$emit('toggleId', expandedId)"
             >
               {{ link.text }}
             </RouterLink>
@@ -118,6 +119,7 @@ onMounted(() => {
           v-for="(menu, idx) of menus"
           :key="idx"
           v-bind="menu"
+          @toggle-id="$emit('toggleId', expandedId)"
         />
       </div>
     </div>

--- a/src/components/DsfrNavigation/DsfrNavigationMegaMenuCategory.md
+++ b/src/components/DsfrNavigation/DsfrNavigationMegaMenuCategory.md
@@ -20,6 +20,7 @@ La catégorie de méga-menu est composée des éléments suivants :
 - un titre de catégorie dans un élément `<h5>` avec lien
 - une liste non-ordonnée (`<ul>`) de liens de navigation
 - chaque lien utilise le composant `DsfrNavigationMenuLink`
+- les clics sur les liens remontent l'événement `toggleId` vers le méga-menu parent pour fermer le menu ouvert
 
 ## 🛠️ Props
 
@@ -31,7 +32,11 @@ La catégorie de méga-menu est composée des éléments suivants :
 
 ## 📡 Événements
 
-`DsfrNavigationMegaMenuCategory` ne déclenche pas d'événements spécifiques.
+`DsfrNavigationMegaMenuCategory` déclenche l'événement suivant :
+
+| nom       | donnée (payload) | description                                                                 |
+|-----------|------------------|-----------------------------------------------------------------------------|
+| `toggleId`| `string`         | Émis au clic sur un lien de catégorie, puis relayé par le méga-menu parent |
 
 ## 🧩 Slots
 

--- a/src/components/DsfrNavigation/DsfrNavigationMegaMenuCategory.vue
+++ b/src/components/DsfrNavigation/DsfrNavigationMegaMenuCategory.vue
@@ -6,6 +6,7 @@ import DsfrNavigationMenuLink from './DsfrNavigationMenuLink.vue'
 export type { DsfrNavigationMegaMenuCategoryProps }
 
 defineProps<DsfrNavigationMegaMenuCategoryProps>()
+defineEmits<{ (event: 'toggleId', id: string): void }>()
 </script>
 
 <template>
@@ -27,6 +28,7 @@ defineProps<DsfrNavigationMegaMenuCategoryProps>()
       >
         <DsfrNavigationMenuLink
           v-bind="link"
+          @toggle-id="$emit('toggleId', $event)"
         />
       </li>
     </ul>


### PR DESCRIPTION
## Contexte

Cette PR corrige un comportement d’accessibilité dans `DsfrNavigation` :

1. Un menu déroulant restait ouvert quand le focus clavier quittait le menu.
2. Un méga-menu restait ouvert après clic sur un lien interne.

## Changements

### Navigation principale
- Ajout d’une gestion `focusin` dans `DsfrNavigation` pour fermer le menu ouvert quand le focus sort du menu.
- Conservation du comportement actuel sur `Escape`.

### Méga-menu
- Propagation de `toggleId` depuis `DsfrNavigationMegaMenuCategory` vers `DsfrNavigationMegaMenu`.
- Fermeture du méga-menu au clic :
  - sur le lien leader,
  - sur un lien de catégorie.

### Tests
- Ajout d’un test : fermeture du menu quand le focus sort du menu ouvert.
- Ajout d’un test : fermeture du méga-menu au clic sur un lien de catégorie.

### Documentation
- Mise à jour de `DsfrNavigation.md` (comportement clavier/focus + événements écoutés et non émis).
- Mise à jour de `DsfrNavigationMegaMenu.md` (émission `toggleId` sur liens internes).
- Mise à jour de `DsfrNavigationMegaMenuCategory.md` (événement `toggleId` documenté).

## Fichiers impactés

- `src/components/DsfrNavigation/DsfrNavigation.vue`
- `src/components/DsfrNavigation/DsfrNavigationMegaMenu.vue`
- `src/components/DsfrNavigation/DsfrNavigationMegaMenuCategory.vue`
- `src/components/DsfrNavigation/DsfrNavigation.spec.ts`
- `src/components/DsfrNavigation/DsfrNavigation.md`
- `src/components/DsfrNavigation/DsfrNavigationMegaMenu.md`
- `src/components/DsfrNavigation/DsfrNavigationMegaMenuCategory.md`

## Vérifications

- lint
- tests 

closes #1300
closes #1301 
