### PR TITLE
fix(DsfrDataTable): 🐛 affiche les boutons d’actions groupées uniquement quand une ligne est sélectionnée

### DIFF
--- a/src/components/DsfrDataTable/DsfrDataTable.spec.ts
+++ b/src/components/DsfrDataTable/DsfrDataTable.spec.ts
@@ -557,6 +557,60 @@ describe('DsfrDataTable', () => {
     })
   })
 
+  it('should not render top bar buttons when no line is selected', () => {
+    // Given
+    const title = 'Selectable Table'
+    const headersRow = ['Name', 'Age']
+    const rows = [
+      ['Alice', '25'],
+      ['Bob', '30'],
+    ]
+    const topBarButtons = [{ label: 'Action groupée' }]
+
+    // When
+    const { queryByText } = render(DsfrDataTable, {
+      props: {
+        title,
+        headersRow,
+        rows,
+        selectableRows: true,
+        topBarButtons,
+      },
+    })
+
+    // Then
+    expect(queryByText('Action groupée')).toBeNull()
+  })
+
+  it('should render top bar buttons when a row is selected (and appropriate props are provided)', async () => {
+    // Given
+    const title = 'Selectable Table'
+    const headersRow = ['Name', 'Age']
+    const rows = [
+      ['Alice', '25'],
+      ['Bob', '30'],
+    ]
+    const topBarButtons = [{ label: 'Action groupée' }]
+
+    // When
+    const { container, getByText } = render(DsfrDataTable, {
+      props: {
+        title,
+        headersRow,
+        rows,
+        selectableRows: true,
+        topBarButtons,
+      },
+    })
+
+    const firstRowCheckbox = container.querySelector('tbody input[id*="row-select-"]') as HTMLInputElement
+    await fireEvent.click(firstRowCheckbox)
+    await nextTick()
+
+    // Then
+    expect(getByText('Action groupée')).toBeTruthy()
+  })
+
   it('should handle pagination with rowsPerPage model', () => {
     // Given
     const title = 'Paginated Table'

--- a/src/components/DsfrDataTable/DsfrDataTable.vue
+++ b/src/components/DsfrDataTable/DsfrDataTable.vue
@@ -393,7 +393,7 @@ onBeforeUnmount(() => {
           name="tableTopBarButtons"
         >
           <DsfrButtonGroup
-            v-if="topBarButtons"
+            v-if="topBarButtons && selection.length > 0"
             :buttons="topBarButtons"
             :size="topBarButtonsSize"
           />


### PR DESCRIPTION
Fixes #1257

## Pourquoi les changements ont été faits :
- Les boutons d’actions groupées (`topBarButtons`) s'affichait même si aucune ligne n’était sélectionnée.
- Le comportement attendu est un affichage conditionné à la sélection effective de lignes.

## Quelles modifications ont été apportées :
- Mise à jour de `DsfrDataTable.vue` :
  - rendu des boutons de `topBarButtons` uniquement si `selection.length > 0`.
- Mise à jour de `DsfrDataTable.spec.ts` :
  - test de non-affichage quand aucune ligne n’est sélectionnée,
  - test d’affichage après sélection d’une ligne.

## Impact
- Comportement aligné avec l’intention UX des actions groupées pourtée par l'équipe DSFR.
- Réduction des régressions via la couverture de tests ajoutée.
