### PR TITLE
fix(DsfrDataTable): 🐛 ignore les erreurs de copie

### DIFF
--- a/agent-instructions/create-pr.md
+++ b/agent-instructions/create-pr.md
@@ -28,7 +28,10 @@ closes #<issue ID>
 
 8. Create the pull request with `gh pr create`.
 9. Link the newly created PR to the issue in GitHub's Development section.
-10. Show a summary with the PR URL, title, base branch, current branch, issue ID, and whether the Development link was verified.
+10. Add the newly created PR to both GitHub Projects:
+   - private project `VueDsfr`, in the `Revue de code en cours` column
+   - public project `Vue Dsfr`, in the `In progress` column
+11. Show a summary with the PR URL, title, base branch, current branch, issue ID, whether the Development link was verified, and whether both project links were updated.
 
 Required title format:
 
@@ -67,8 +70,11 @@ Rules:
 - Write the generated pull request title and body in French, except for technical identifiers, branch names, URLs, commands, and code symbols.
 - Keep the title concise and specific.
 - Link the newly created PR to the issue through the closing reference in the PR body.
-- Do not try to link the branch to the issue before creating the PR.
+- After creating the PR, explicitly verify that the PR is linked to the issue in GitHub's Development section.
+- After creating the PR, add it to the private GitHub Project `VueDsfr`, then move it to the `Revue de code en cours` column.
+- After creating the PR, add it to the public GitHub Project `Vue Dsfr`, then move it to the `In progress` column.
 - Do not invent or call unsupported REST or GraphQL endpoints for directly linking an existing PR to an issue.
+- If the project update cannot be completed because a project is not visible, the field names differ, or permissions are missing, report the blocker clearly and keep the PR creation result.
 - Use `gh pr create` to create the pull request.
 - Do not commit, push, edit files, stage files, or unstage files as part of this workflow.
 - Preserve the user's existing worktree changes.
@@ -105,4 +111,8 @@ gh pr create --base <base branch> --head <current branch> --title "<title>" --bo
 gh issue develop --list <issue ID>
 ```
 
-- Show the created PR URL and a concise summary, including whether the branch or PR appears linked to the issue in Development.
+- Add the PR to both GitHub Projects and set its status:
+  - private project `VueDsfr`: `Revue de code en cours`
+  - public project `Vue Dsfr`: `In progress`
+
+- Show the created PR URL and a concise summary, including whether the branch or PR appears linked to the issue in Development and whether both GitHub Projects were updated.

--- a/src/components/DsfrDataTable/DsfrDataTable.spec.ts
+++ b/src/components/DsfrDataTable/DsfrDataTable.spec.ts
@@ -1241,4 +1241,98 @@ describe('DsfrDataTable', () => {
       offsetWidthSpy.mockRestore()
     }
   })
+
+  it('copie la valeur de cellule avec le raccourci Ctrl+C', async () => {
+    // Given
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    const clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard')
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+
+    try {
+      const { container } = render(DsfrDataTable, {
+        props: {
+          title: 'Table avec copie',
+          headersRow: ['Nom', 'Ville'],
+          rows: [['Alice', 'Paris']],
+        },
+      })
+      const firstCell = container.querySelector('tbody td') as HTMLTableCellElement
+
+      // When
+      await fireEvent.keyDown(firstCell, { code: 'KeyC', ctrlKey: true, key: 'c' })
+
+      // Then
+      expect(writeText).toHaveBeenCalledWith('Alice')
+    } finally {
+      if (clipboardDescriptor) {
+        Object.defineProperty(navigator, 'clipboard', clipboardDescriptor)
+      } else {
+        delete (navigator as Partial<Navigator>).clipboard
+      }
+    }
+  })
+
+  it('ignore le refus navigateur lors de la copie au clavier', async () => {
+    // Given
+    const writeText = vi.fn().mockRejectedValue(new DOMException('Clipboard write is not allowed', 'NotAllowedError'))
+    const clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard')
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+
+    try {
+      const { container } = render(DsfrDataTable, {
+        props: {
+          title: 'Table avec copie refusée',
+          headersRow: ['Nom', 'Ville'],
+          rows: [['Alice', 'Paris']],
+        },
+      })
+      const firstCell = container.querySelector('tbody td') as HTMLTableCellElement
+
+      // When
+      await fireEvent.keyDown(firstCell, { code: 'KeyC', ctrlKey: true, key: 'c' })
+      await nextTick()
+
+      // Then
+      expect(writeText).toHaveBeenCalledWith('Alice')
+    } finally {
+      if (clipboardDescriptor) {
+        Object.defineProperty(navigator, 'clipboard', clipboardDescriptor)
+      } else {
+        delete (navigator as Partial<Navigator>).clipboard
+      }
+    }
+  })
+
+  it('ignore la copie clavier lorsque l’API presse-papiers est absente', async () => {
+    // Given
+    const clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard')
+    delete (navigator as Partial<Navigator>).clipboard
+
+    try {
+      const { container } = render(DsfrDataTable, {
+        props: {
+          title: 'Table sans presse-papiers',
+          headersRow: ['Nom', 'Ville'],
+          rows: [['Alice', 'Paris']],
+        },
+      })
+      const firstCell = container.querySelector('tbody td') as HTMLTableCellElement
+
+      // When
+      await fireEvent.keyDown(firstCell, { code: 'KeyC', ctrlKey: true, key: 'c' })
+
+      // Then
+      expect(firstCell).toBeTruthy()
+    } finally {
+      if (clipboardDescriptor) {
+        Object.defineProperty(navigator, 'clipboard', clipboardDescriptor)
+      }
+    }
+  })
 })

--- a/src/components/DsfrDataTable/DsfrDataTable.vue
+++ b/src/components/DsfrDataTable/DsfrDataTable.vue
@@ -189,8 +189,12 @@ function onPaginationOptionsChange () {
   selection.value.length = 0
 }
 
-function copyToClipboard (text: string) {
-  navigator.clipboard.writeText(text)
+async function copyToClipboard (text: string) {
+  try {
+    await navigator.clipboard?.writeText?.(text)
+  } catch {
+    // L'écriture dans le presse-papiers peut être refusée par le navigateur.
+  }
 }
 
 // rendu tenant compte du JS table DSFR


### PR DESCRIPTION
## Résumé
- Empêche `DsfrDataTable` de remonter une erreur lorsque le navigateur refuse l’écriture dans le presse-papiers.
- Absorbe les rejets de `navigator.clipboard.writeText()` déclenchés par le raccourci clavier de copie.
- Ajoute une couverture de test pour la copie au clavier et le refus d’accès au presse-papiers.

## Vérification
- `pnpm test:unit src/components/DsfrDataTable/DsfrDataTable.spec.ts`
- `pnpm lint src/components/DsfrDataTable/DsfrDataTable.vue src/components/DsfrDataTable/DsfrDataTable.spec.ts`

closes #1352
