### PR TITLE
Documente les commandes d’assistance multi-agent

### DIFF
--- a/.agents/skills/commit-conventions/tasks.md
+++ b/.agents/skills/commit-conventions/tasks.md
@@ -127,6 +127,18 @@ closes #1337
 > Vérifie que la Pull Request cible bien `develop` (jamais `main` ni d’autres branches).
 > Si la cible est incorrecte, indique la correction à appliquer.
 
+## 📋 Mettre à jour les projets GitHub après une Pull Request
+
+> Après la création d’une Pull Request, appliquer le workflow commun décrit dans [`../../../agent-instructions/create-pr.md`](../../../agent-instructions/create-pr.md).
+>
+> - Découvrir les numéros des projets `VueDsfr` et `Vue Dsfr` avec `gh project list --owner dnum-mi --limit 200 --format json`.
+> - Ajouter la Pull Request par son URL avec `gh project item-add`.
+> - Définir le statut par son nom avec `gh project item-edit <numéro> --owner dnum-mi --url <URL de PR> --field Status --value <statut>`.
+> - Vérifier l’état final avec `gh project item-list`.
+> - Ne recourir aux identifiants GraphQL que lorsqu’une commande ne permet pas d’utiliser le numéro du projet, l’URL et le nom du champ.
+>
+> L’ajout au projet privé `VueDsfr` est facultatif : si le projet n’est pas visible ou si les permissions manquent, l’ignorer après un seul essai et poursuivre avec le projet public `Vue Dsfr`. Pour le lien avec l’issue, conserver `closes #<numéro>` dans le corps de la Pull Request. `gh issue develop --list` vérifie les branches liées, pas les Pull Requests.
+
 ## 🧭 Arbitrer le type de commit
 
 > En cas d’hésitation entre plusieurs types (`fix`, `feat`, `refactor`, `docs`, etc.),

--- a/agent-instructions/create-pr.md
+++ b/agent-instructions/create-pr.md
@@ -27,11 +27,10 @@ closes #<issue ID>
 ```
 
 8. Create the pull request with `gh pr create`.
-9. Link the newly created PR to the issue in GitHub's Development section.
-10. Add the newly created PR to both GitHub Projects:
-   - private project `VueDsfr`, in the `Revue de code en cours` column
-   - public project `Vue Dsfr`, in the `In progress` column
-11. Show a summary with the PR URL, title, base branch, current branch, issue ID, whether the Development link was verified, and whether both project links were updated.
+9. Verify that the pull request body contains the closing reference and inspect GitHub's linked-issue metadata when available.
+10. If it is visible to the current contributor, add the newly created PR to the private GitHub Project `VueDsfr`, in the `Revue de code en cours` column.
+11. Add the newly created PR to the public GitHub Project `Vue Dsfr`, in the `In progress` column.
+12. Show a summary with the PR URL, title, base branch, current branch, issue ID, whether the linked-issue metadata was available, and the result for each project.
 
 Required title format:
 
@@ -73,11 +72,14 @@ Rules:
 - Pass the title through an argument-safe API. If only a shell is available, write the title to a temporary file and read that file as a single quoted argument instead of embedding the generated title directly in the command.
 - Keep the title concise and specific.
 - Link the newly created PR to the issue through the closing reference in the PR body.
-- After creating the PR, explicitly verify that the PR is linked to the issue in GitHub's Development section.
-- After creating the PR, add it to the private GitHub Project `VueDsfr`, then move it to the `Revue de code en cours` column.
+- A `closes #<issue ID>` reference in the PR body is the required repository-level linkage. The `check-pr-linked-issue` workflow validates this reference.
+- `gh issue develop --list <issue ID>` lists linked branches only. Do not use an empty result as evidence that the pull request is unlinked.
+- `gh pr view <PR number> --json closingIssuesReferences` can expose GitHub's linked-issue metadata, but it can remain empty for a PR targeting `develop` because GitHub only closes issues when merging into the repository's default branch.
+- Do not attempt unsupported REST or GraphQL mutations to force a Development link. Report the verified closing reference and the metadata result separately.
+- Attempt the private GitHub Project `VueDsfr` only once. If it is not visible or the contributor lacks permission, skip it without retrying and report it as skipped; this does not block the workflow.
 - After creating the PR, add it to the public GitHub Project `Vue Dsfr`, then move it to the `In progress` column.
 - Do not invent or call unsupported REST or GraphQL endpoints for directly linking an existing PR to an issue.
-- If the project update cannot be completed because a project is not visible, the field names differ, or permissions are missing, report the blocker clearly and keep the PR creation result.
+- If the public project update cannot be completed because the project is not visible, field names differ, or permissions are missing, report the blocker clearly and keep the PR creation result.
 - Use `gh pr create` to create the pull request.
 - Do not commit, push, edit files, stage files, or unstage files as part of this workflow.
 - Preserve the user's existing worktree changes.
@@ -111,11 +113,60 @@ gh pr create --base <base branch> --head <current branch> --title "$(cat <title-
 - After creating the PR, verify the issue's Development linkage:
 
 ```text
-gh issue develop --list <issue ID>
+gh pr view <PR number> --json closingIssuesReferences,url
 ```
 
-- Add the PR to both GitHub Projects and set its status:
-  - private project `VueDsfr`: `Revue de code en cours`
-  - public project `Vue Dsfr`: `In progress`
+- Confirm the PR body still contains `closes #<issue ID>`. The repository workflow accepts this reference even if `closingIssuesReferences` is empty for a `develop`-targeted PR.
+- Add the PR to both GitHub Projects and set its status using the project number, the PR URL, and the human-readable status name. Prefer this form over GraphQL node IDs:
 
-- Show the created PR URL and a concise summary, including whether the branch or PR appears linked to the issue in Development and whether both GitHub Projects were updated.
+```text
+gh project item-add <project number> --owner dnum-mi --url <PR URL> --format json
+gh project item-edit <project number> --owner dnum-mi --url <PR URL> --field Status --value <status name>
+```
+
+## GitHub Projects discovery
+
+Project numbers are stable identifiers for this workflow. GraphQL node IDs returned by `--format json` are only needed for machine-oriented calls that cannot use `--url`, `--field`, and `--value`.
+
+Discover project numbers and visibility before an update instead of relying on stale IDs:
+
+```text
+gh project list --owner dnum-mi --limit 200 --format json --jq '.projects[] | select(.title == "VueDsfr" or .title == "Vue Dsfr") | {number, id, public, title}'
+```
+
+Expected projects:
+
+| Project | Visibility | Project number | Status | Behavior |
+| --- | --- | --- | --- | --- |
+| `VueDsfr` | private | `6` | `Revue de code en cours` | optional: skip if unavailable |
+| `Vue Dsfr` | public | `49` | `In progress` | required attempt |
+
+Inspect the available status options before setting them. Names are case-sensitive:
+
+```text
+gh project field-list <project number> --owner dnum-mi --format json --jq '.fields[] | select(.name == "Status") | {id, name, options}'
+```
+
+If the private project appears in the discovery result, add and update it once:
+
+```text
+gh project item-add 6 --owner dnum-mi --url <PR URL> --format json
+gh project item-edit 6 --owner dnum-mi --url <PR URL> --field Status --value "Revue de code en cours"
+```
+
+If either command fails because the project is inaccessible, do not retry it. Continue with the public project:
+
+```text
+gh project item-add 49 --owner dnum-mi --url <PR URL> --format json
+gh project item-edit 49 --owner dnum-mi --url <PR URL> --field Status --value "In progress"
+```
+
+Verify each update by locating the PR URL and its status:
+
+```text
+gh project item-list <project number> --owner dnum-mi --limit 500 --format json
+```
+
+Use `--jq` to filter the JSON output when the project is large. If the private project, its status field, or its permissions are unavailable, report that it was skipped and continue. If the public project is unavailable, report the exact blocked step while preserving the PR creation result.
+
+- Show the created PR URL and a concise summary, including the linked-issue metadata result, the private-project result (`updated` or `skipped`), and the public-project result.

--- a/docs/guide/guide-contributeur.md
+++ b/docs/guide/guide-contributeur.md
@@ -57,13 +57,18 @@ fix(DsfrRadioButton): 🐛 corrige le type des props
 fixes #1080
 ```
 
-::: tip Astuce
+### Commandes et prompts d’assistance
 
-Demander à copilot de créer le commit.
+Le dépôt fournit des aides communes pour automatiser les étapes GitHub courantes avec Codex, Claude Code et GitHub Copilot. Elles s’appuient sur les mêmes instructions sources dans `agent-instructions/`.
 
-En effet, le projet contient des instructions qui sont normalement automatiquement par copilot et qui écriront des messages de commit formattés selon les conventions du projet.
+| Action | Codex | Claude Code | GitHub Copilot | Rôle |
+| --- | --- | --- | --- | --- |
+| Créer un commit depuis les fichiers indexés | `$commit-staged` | `/commit-staged` | prompt `commit-staged` | Analyse le diff indexé et crée un commit conforme aux conventions du projet. |
+| Créer une issue depuis les fichiers indexés | `$create-issue` | `/create-issue` | prompt `create-issue` | Rédige puis crée une issue GitHub en français à partir des changements indexés. |
+| Créer une branche depuis une issue | `$create-branch <numéro>` | `/create-branch <numéro>` | prompt `create-branch` | Lit l’issue GitHub et crée une branche locale au format `type/description-numéro`. |
+| Créer une pull request | `$create-pr` | `/create-pr` | prompt `create-pr` | Crée la PR vers `develop`, ajoute le lien d’issue et met à jour les projets GitHub attendus. |
 
-:::
+Dans Copilot, ces aides sont des prompts disponibles dans `.github/prompts/`. Dans Claude Code, ce sont des commandes slash dans `.claude/commands/`. Dans Codex, ce sont des commandes custom dans `.codex/commands/`.
 
 ### Langue et communication
 

--- a/docs/guide/guide-contributeur.md
+++ b/docs/guide/guide-contributeur.md
@@ -63,10 +63,10 @@ Le dépôt fournit des aides communes pour automatiser les étapes GitHub couran
 
 | Action | Codex | Claude Code | GitHub Copilot | Rôle |
 | --- | --- | --- | --- | --- |
-| Créer un commit depuis les fichiers indexés | `$commit-staged` | `/commit-staged` | prompt `commit-staged` | Analyse le diff indexé et crée un commit conforme aux conventions du projet. |
-| Créer une issue depuis les fichiers indexés | `$create-issue` | `/create-issue` | prompt `create-issue` | Rédige puis crée une issue GitHub en français à partir des changements indexés. |
-| Créer une branche depuis une issue | `$create-branch <numéro>` | `/create-branch <numéro>` | prompt `create-branch` | Lit l’issue GitHub et crée une branche locale au format `type/description-numéro`. |
-| Créer une pull request | `$create-pr` | `/create-pr` | prompt `create-pr` | Crée la PR vers `develop`, ajoute le lien d’issue et met à jour les projets GitHub attendus. |
+| Créer un commit depuis les fichiers indexés | `$commit-staged` | `/commit-staged` | `/commit-staged` | Analyse le diff indexé et crée un commit conforme aux conventions du projet. |
+| Créer une issue depuis les fichiers indexés | `$create-issue` | `/create-issue` | `/create-issue` | Rédige puis crée une issue GitHub en français à partir des changements indexés. |
+| Créer une branche depuis une issue | `$create-branch <numéro>` | `/create-branch <numéro>` | `/create-branch <numéro>` | Lit l’issue GitHub et crée une branche locale au format `type/description-numéro`. |
+| Créer une pull request | `$create-pr` | `/create-pr` | `/create-pr` | Crée la PR vers `develop`, ajoute le lien d’issue et met à jour les projets GitHub attendus. |
 
 Dans Copilot, ces aides sont des prompts disponibles dans `.github/prompts/`. Dans Claude Code, ce sont des commandes slash dans `.claude/commands/`. Dans Codex, ce sont des commandes custom dans `.codex/commands/`.
 


### PR DESCRIPTION
## Résumé
- Documente les commandes et prompts partagés par Codex, Claude Code et GitHub Copilot.
- Présente les workflows de commit, d’issue, de branche et de Pull Request.
- Indique les emplacements des adaptations propres à chaque agent.

## Vérification
- Vérification du diff indexé avec `git diff --cached --check`.
- Non exécuté : modification documentaire uniquement.

closes #1366
