### PR TITLE
Corrige le viewBox invalide dans VIconOffline quand left et top sont absents de la collection

### DIFF
--- a/src/components/VIconOffline/VIconOffline.vue
+++ b/src/components/VIconOffline/VIconOffline.vue
@@ -34,8 +34,8 @@ const icon = computed<IconifyIcon | null>(() => {
   return {
     ...iconData,
     height: iconData.height ?? collection.height,
-    left: iconData.left ?? collection.left,
-    top: iconData.top ?? collection.top,
+    left: iconData.left ?? collection.left ?? 0,
+    top: iconData.top ?? collection.top ?? 0,
     width: iconData.width ?? collection.width,
   }
 })


### PR DESCRIPTION
## Résumé

- Quand la collection générée par `vue-dsfr-icons` ne définit que `width` et `height` (sans `left` ni `top`), les propriétés de l'objet `IconifyIcon` résultant sont `undefined`
- Le composant `Icon` d'`@iconify/vue/offline` produit alors `viewBox="  24 24"` au lieu de `viewBox="0 0 24 24"`, rendant l'icône invisible
- Ajout de `?? 0` comme valeur de repli sur `left` et `top` dans le computed `icon` de `VIconOffline.vue`

## Vérification

- Non exécuté

closes #1372
