### PR TITLE
Corrige resolveOfflineIcon pour supporter le format prefix-nom

### DIFF
--- a/src/components/VIcon/VIcon.ssr.spec.ts
+++ b/src/components/VIcon/VIcon.ssr.spec.ts
@@ -41,6 +41,14 @@ describe('VIcon (résolution offline en SSR)', () => {
     expect(html).not.toContain('vicon-loading')
   })
 
+  it('rend le SVG résolu localement pour le format prefix-nom utilisé par DsfrButton/DsfrTag/etc.', async () => {
+    const html = await renderIcon({ name: 'ri-flag-line', ssr: true })
+
+    expect(html).toContain('<svg')
+    expect(html).toContain('<path d="M3 3h18v18H3z"')
+    expect(html).not.toContain('vicon-loading')
+  })
+
   it('n’effectue aucun appel réseau pour une icône résolue localement', async () => {
     const fetch = vi.fn()
     vi.stubGlobal('fetch', fetch)

--- a/src/utils/resolve-offline-icon.spec.ts
+++ b/src/utils/resolve-offline-icon.spec.ts
@@ -14,8 +14,20 @@ const collections: IconifyJSON[] = [{
 }]
 
 describe('resolve-offline-icon', () => {
-  it('should resolve an icon present in the local collections', () => {
+  it('should resolve an icon using the colon-separated format (prefix:name)', () => {
     const icon = resolveOfflineIcon('ri:flag-line', collections)
+
+    expect(icon).toEqual({
+      body: '<path d="M3 3h18v18H3z" />',
+      height: 24,
+      left: 0,
+      top: 0,
+      width: 24,
+    })
+  })
+
+  it('should resolve an icon using the hyphen-separated format (prefix-name), as used by DsfrButton/DsfrTag/etc.', () => {
+    const icon = resolveOfflineIcon('ri-flag-line', collections)
 
     expect(icon).toEqual({
       body: '<path d="M3 3h18v18H3z" />',
@@ -28,15 +40,19 @@ describe('resolve-offline-icon', () => {
 
   it('should return null when the icon is absent from the local collections', () => {
     expect(resolveOfflineIcon('ri:missing-icon', collections)).toBeNull()
+    expect(resolveOfflineIcon('ri-missing-icon', collections)).toBeNull()
   })
 
   it('should return null when the collection prefix is unknown', () => {
     expect(resolveOfflineIcon('unknown:flag-line', collections)).toBeNull()
+    expect(resolveOfflineIcon('unknown-flag-line', collections)).toBeNull()
   })
 
   it('should return null when the name is malformed', () => {
-    expect(resolveOfflineIcon('flag-line', collections)).toBeNull()
+    expect(resolveOfflineIcon('flagline', collections)).toBeNull()
     expect(resolveOfflineIcon(':flag-line', collections)).toBeNull()
     expect(resolveOfflineIcon('ri:', collections)).toBeNull()
+    expect(resolveOfflineIcon('-flag-line', collections)).toBeNull()
+    expect(resolveOfflineIcon('ri-', collections)).toBeNull()
   })
 })

--- a/src/utils/resolve-offline-icon.ts
+++ b/src/utils/resolve-offline-icon.ts
@@ -1,21 +1,22 @@
 import type { IconifyIcon, IconifyJSON } from '@iconify/vue'
 
 /**
- * Résout une icône `prefix:nom` depuis des collections Iconify locales.
+ * Résout une icône `prefix:nom` ou `prefix-nom` depuis des collections Iconify locales.
+ *
+ * Les deux formats sont acceptés pour rester cohérent avec `@iconify/vue`, qui accepte
+ * lui aussi la syntaxe `prefix-nom` (utilisée notamment par `DsfrButton`, `DsfrTag`, etc.).
  *
  * Retourne `null` si le nom est mal formé ou si l’icône n’est présente
  * dans aucune des collections fournies.
  */
 export function resolveOfflineIcon (name: string, collections: readonly IconifyJSON[]): IconifyIcon | null {
-  const separatorIndex = name.indexOf(':')
-  if (separatorIndex <= 0 || separatorIndex === name.length - 1) {
+  const parsedName = parseIconName(name)
+  if (!parsedName) {
     return null
   }
 
-  const prefix = name.slice(0, separatorIndex)
-  const iconName = name.slice(separatorIndex + 1)
-  const collection = collections.find(item => item.prefix === prefix)
-  const iconData = collection?.icons[iconName]
+  const collection = collections.find(item => item.prefix === parsedName.prefix)
+  const iconData = collection?.icons[parsedName.name]
 
   if (!collection || !iconData) {
     return null
@@ -28,4 +29,24 @@ export function resolveOfflineIcon (name: string, collections: readonly IconifyJ
     top: iconData.top ?? collection.top ?? 0,
     width: iconData.width ?? collection.width,
   }
+}
+
+function parseIconName (name: string): { name: string, prefix: string } | null {
+  const colonIndex = name.indexOf(':')
+  if (colonIndex > 0 && colonIndex < name.length - 1) {
+    return {
+      name: name.slice(colonIndex + 1),
+      prefix: name.slice(0, colonIndex),
+    }
+  }
+
+  const hyphenIndex = name.indexOf('-')
+  if (hyphenIndex > 0 && hyphenIndex < name.length - 1) {
+    return {
+      name: name.slice(hyphenIndex + 1),
+      prefix: name.slice(0, hyphenIndex),
+    }
+  }
+
+  return null
 }


### PR DESCRIPTION
## Résumé
- `resolveOfflineIcon` ne reconnaissait que le format `prefix:nom`, alors que `@iconify/vue` accepte aussi en interne `prefix-nom` — le format utilisé par `DsfrButton`, `DsfrTag`, et les exemples de `VIcon` (ex. `ri-close-line`)
- pour ces icônes, `preferOffline` retombait silencieusement sur le registre Iconify en ligne au lieu de les résoudre localement
- extrait une fonction `parseIconName` qui reconnaît `prefix:nom` en priorité, puis `prefix-nom`
- ajoute les tests correspondants, dont un test SSR bout en bout confirmant le rendu local sans placeholder

## Vérification
- `pnpm test:unit` : tous les tests passent
- `pnpm lint` : 0 erreur
- `pnpm check-exports` : ok
- `pnpm build` : ok

closes #1386
