### PR TITLE
Corrige le typage et l’héritage des tags sélectionnables

### DIFF
--- a/src/components/DsfrTag/DsfrTag.spec.ts
+++ b/src/components/DsfrTag/DsfrTag.spec.ts
@@ -100,7 +100,9 @@ describe('DsfrTags', () => {
     type TagValue = 'fruit' | 'legume'
     const tags: DsfrTagsProps<TagValue>['tags'] = [
       {
+        class: 'tag-personnalise',
         label: 'Les fruits',
+        selected: false,
         selectable: true,
         value: 'fruit',
       },
@@ -128,6 +130,7 @@ describe('DsfrTags', () => {
     const unselectedTag = getByRole('button', { name: 'Les légumes' })
 
     // Alors
+    expect(selectedTag).toHaveClass('tag-personnalise')
     expect(selectedTag).toHaveAttribute('aria-pressed', 'true')
     expect(unselectedTag).toHaveAttribute('aria-pressed', 'false')
   })

--- a/src/components/DsfrTag/DsfrTag.spec.ts
+++ b/src/components/DsfrTag/DsfrTag.spec.ts
@@ -1,3 +1,5 @@
+import type { DsfrTagsProps } from './DsfrTags.types'
+
 import { render } from '@testing-library/vue'
 // import '@gouvfr/dsfr/dist/core/core.module.js'
 
@@ -91,5 +93,42 @@ describe('DsfrTags', () => {
     // Then
     expect(firstTagEl).toHaveClass('fr-tag')
     expect(secondTagEl).toHaveClass('fr-tag')
+  })
+
+  it('déduit l’état sélectionné depuis modelValue', () => {
+    // Étant donné
+    type TagValue = 'fruit' | 'legume'
+    const tags: DsfrTagsProps<TagValue>['tags'] = [
+      {
+        label: 'Les fruits',
+        selectable: true,
+        value: 'fruit',
+      },
+      {
+        label: 'Les légumes',
+        selectable: true,
+        value: 'legume',
+      },
+    ]
+
+    // Quand
+    const { getByRole } = render(DsfrTags, {
+      global: {
+        components: {
+          VIcon,
+        },
+      },
+      props: {
+        modelValue: ['fruit'],
+        tags,
+      },
+    })
+
+    const selectedTag = getByRole('button', { name: 'Les fruits' })
+    const unselectedTag = getByRole('button', { name: 'Les légumes' })
+
+    // Alors
+    expect(selectedTag).toHaveAttribute('aria-pressed', 'true')
+    expect(unselectedTag).toHaveAttribute('aria-pressed', 'false')
   })
 })

--- a/src/components/DsfrTag/DsfrTags.md
+++ b/src/components/DsfrTag/DsfrTags.md
@@ -16,7 +16,7 @@ Ce composant affiche une liste de tags sous forme de `<ul>` et permet d'associer
 
 | Nom           | Type                          | Par défaut | Description |
 |--------------|------------------------------|-----------|-------------|
-| `tags`       | `DsfrTagProps<T>[]`          | `[]`      | Liste des tags à afficher. |
+| `tags`       | `DsfrTagsTagProps<T>[]`      | `[]`      | Liste des tags à afficher. |
 | `modelValue` | `T[]`                        | `undefined` | Liste des valeurs des tags sélectionnés (si les tags sont sélectionnables). |
 
 ## 📡 Événements

--- a/src/components/DsfrTag/DsfrTags.types.ts
+++ b/src/components/DsfrTag/DsfrTags.types.ts
@@ -1,4 +1,7 @@
 import type VIcon from '../VIcon/VIcon.vue'
+import type { HTMLAttributes } from 'vue'
+
+type DsfrTagHtmlAttributes = Omit<HTMLAttributes, 'onSelect'>
 
 interface DsfrTagCommonProps {
   label?: string
@@ -32,7 +35,7 @@ export type DsfrTagProps<T = string> = DsfrTagCommonProps & (
 
 export type DsfrTagsTagProps<T = string> = DsfrTagCommonProps & (
   DsfrTagsSelectableProps<T> | DsfrTagNonSelectableProps
-)
+) & DsfrTagHtmlAttributes
 
 export type DsfrTagsProps<T = string> = {
   tags: DsfrTagsTagProps<T>[]

--- a/src/components/DsfrTag/DsfrTags.types.ts
+++ b/src/components/DsfrTag/DsfrTags.types.ts
@@ -1,6 +1,6 @@
 import type VIcon from '../VIcon/VIcon.vue'
 
-export type DsfrTagProps<T = string> = {
+interface DsfrTagCommonProps {
   label?: string
   link?: string
   tagName?: string
@@ -8,17 +8,33 @@ export type DsfrTagProps<T = string> = {
   disabled?: boolean
   small?: boolean
   iconOnly?: boolean
-} & ({
+}
+
+type DsfrTagSelectableProps<T = string> = {
   selectable: true
   selected: boolean | undefined
   value: T
-} | {
+}
+
+type DsfrTagNonSelectableProps = {
   selectable?: false | undefined
   selected?: never
   value?: never
-})
+}
+
+type DsfrTagsSelectableProps<T = string> = Omit<DsfrTagSelectableProps<T>, 'selected'> & {
+  selected?: boolean
+}
+
+export type DsfrTagProps<T = string> = DsfrTagCommonProps & (
+  DsfrTagSelectableProps<T> | DsfrTagNonSelectableProps
+)
+
+export type DsfrTagsTagProps<T = string> = DsfrTagCommonProps & (
+  DsfrTagsSelectableProps<T> | DsfrTagNonSelectableProps
+)
 
 export type DsfrTagsProps<T = string> = {
-  tags: DsfrTagProps<T>[]
+  tags: DsfrTagsTagProps<T>[]
   modelValue?: T[]
 }

--- a/src/components/DsfrTag/DsfrTags.vue
+++ b/src/components/DsfrTag/DsfrTags.vue
@@ -23,7 +23,6 @@ function onSelect ([value, selected]: [unknown, boolean]) {
     return
   }
   // Ajouter la valeur si elle n'est pas déjà présente
-  // eslint-disable-next-line unicorn/prefer-includes
   const alreadyExists = currentValue.some(v => v === value)
   if (!alreadyExists) {
     const newValue = [...currentValue, value]
@@ -40,13 +39,7 @@ function onSelect ([value, selected]: [unknown, boolean]) {
     >
       <DsfrTag
         v-if="tag.selectable"
-        :label="tag.label"
-        :link="tag.link"
-        :tag-name="tag.tagName"
-        :icon="tag.icon"
-        :disabled="tag.disabled"
-        :small="tag.small"
-        :icon-only="tag.iconOnly"
+        v-bind="tag"
         :selectable="true"
         :selected="modelValue?.includes(tag.value) || false"
         :value="tag.value"
@@ -54,13 +47,7 @@ function onSelect ([value, selected]: [unknown, boolean]) {
       />
       <DsfrTag
         v-else
-        :label="tag.label"
-        :link="tag.link"
-        :tag-name="tag.tagName"
-        :icon="tag.icon"
-        :disabled="tag.disabled"
-        :small="tag.small"
-        :icon-only="tag.iconOnly"
+        v-bind="tag"
       />
     </li>
   </ul>

--- a/src/components/DsfrTag/docs-demo/DsfrTagsDemo.vue
+++ b/src/components/DsfrTag/docs-demo/DsfrTagsDemo.vue
@@ -1,15 +1,16 @@
 <script lang="ts" setup>
-import type { DsfrTagProps } from '@/components/DsfrTag/DsfrTags.types.ts'
+import type { DsfrTagsTagProps } from '@/components/DsfrTag/DsfrTags.types.ts'
 
 import { computed, ref } from 'vue'
 
 import DsfrTags from '@/components/DsfrTag/DsfrTags.vue'
 
-const tagSet: (DsfrTagProps)[] = [
+type FruitOrVegetable = 'fruit' | 'legume'
+
+const tagSet: (DsfrTagsTagProps<FruitOrVegetable>)[] = [
   {
     label: 'Les fruits',
     selectable: true,
-    selected: true,
     value: 'fruit',
   },
   {
@@ -18,8 +19,6 @@ const tagSet: (DsfrTagProps)[] = [
     value: 'legume',
   },
 ]
-
-type FruitOrVegetable = 'fruit' | 'legume'
 
 const items: { name: string, type: FruitOrVegetable }[] = [
   {


### PR DESCRIPTION
## Résumé
- Sépare le type des props de `DsfrTag` du type des éléments acceptés par `DsfrTags`.
- Rend `selected` optionnel pour les tags passés à `DsfrTags`, car la sélection vient de `modelValue`.
- Transmet les attributs HTML portés par chaque objet `tag` à `DsfrTag`, sans casser le calcul de sélection.
- Met à jour la documentation, la démo et les tests de non-régression associés.

## Vérification
- `/Users/stan/.volta/bin/pnpm test:unit src/components/DsfrTag/DsfrTag.spec.ts`
- `/Users/stan/.volta/bin/pnpm exec vue-tsc --noEmit -p tsconfig.app.json`
- `/Users/stan/.volta/bin/pnpm exec eslint src/components/DsfrTag/DsfrTags.types.ts src/components/DsfrTag/DsfrTags.vue src/components/DsfrTag/DsfrTag.spec.ts`

closes #1363
closes #1247
