### PR TITLE
Met à jour @gouvfr/dsfr vers 1.15.2 et documente la validation des CGU DSFR

### DIFF
--- a/.github/workflows/publish-release-beta.yml
+++ b/.github/workflows/publish-release-beta.yml
@@ -30,6 +30,8 @@ jobs:
         with:
           version: 11.21.0
       - name: Install dependencies
+        env:
+          DSFR_ACCEPT_LICENSE: '1'
         run: pnpm install --frozen-lockfile
       - name: Release
         env:

--- a/.github/workflows/publish-release-next.yml
+++ b/.github/workflows/publish-release-next.yml
@@ -30,6 +30,8 @@ jobs:
         with:
           version: 11.21.0
       - name: Install dependencies
+        env:
+          DSFR_ACCEPT_LICENSE: '1'
         run: pnpm install --frozen-lockfile
       - name: Release
         env:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -30,6 +30,8 @@ jobs:
         with:
           version: 11.21.0
       - name: Install dependencies
+        env:
+          DSFR_ACCEPT_LICENSE: '1'
         run: pnpm install --frozen-lockfile
       - name: Debug OIDC context
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,6 +29,8 @@ jobs:
         with:
           version: 11.21.0
       - name: Install dependencies
+        env:
+          DSFR_ACCEPT_LICENSE: '1'
         run: pnpm install --frozen-lockfile
       - name: Lint (show only errors)
         run: pnpm lint --quiet

--- a/.gitignore
+++ b/.gitignore
@@ -332,3 +332,6 @@ meta-dts/
 # Vitepress
 .vitepress/dist
 .vitepress/cache
+
+# DSFR
+.dsfr.yml

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ de composants. Il peut s'utiliser facilement en tant que plugin.
 
 ## Comment l’utiliser
 
+> ⚠️ Depuis le DSFR 1.15, l'installation nécessite de valider les CGU du DSFR (script de pré-installation).
+> Voir le [guide d'installation détaillé](https://vue-ds.fr/guide/pour-commencer) en cas d'échec de
+> `npm install`/`pnpm install`.
+
 La façon la plus simple de commencer un projet est d’utiliser le package `create-vue-dsfr`, qui permet de créer un projet NPM avec le nécessaire et suffisant (ou plus, selon votre choix) pour développer un projet utilisant VueDsfr, que ce soit pour Vite (Vue3) ou pour Nuxt (Nuxt3), avec TypeScript et ESLint.
 
 Avec npm :

--- a/docs/guide/migrations.md
+++ b/docs/guide/migrations.md
@@ -1,5 +1,63 @@
 # Migrations
 
+## Migration vers 9.x (DSFR 1.15+)
+
+::: danger Changement de comportement à l'installation
+
+À partir de `@gouvfr/dsfr` 1.15 (utilisé par VueDsfr 9.x), **`npm install` / `pnpm install` / `yarn install`
+peut désormais échouer** si les CGU du DSFR n'ont pas été validées dans votre projet. Ce n'est pas un bug :
+c'est une contrainte introduite par le DSFR lui-même, que VueDsfr ne peut pas contourner.
+
+:::
+
+### Ce qui change
+
+- `@gouvfr/dsfr` embarque un script `preinstall` qui vérifie la présence et la validité d'un fichier
+  `.dsfr.yml` à la racine de votre projet.
+- Ce fichier est créé/mis à jour par l'assistant officiel du DSFR (`pnpm create @gouvfr/dsfr` /
+  `npm create @gouvfr/dsfr` / `yarn create @gouvfr/dsfr`), qui vous présente les CGU à valider.
+- Avec **pnpm ≥ 10**, il faut en plus autoriser explicitement l'exécution de ce script (bloqué par défaut) :
+  `pnpm approve-builds @gouvfr/dsfr` ou `pnpm add ... --allow-build=@gouvfr/dsfr`.
+
+Voir la procédure complète dans le [guide « Pour commencer »](./pour-commencer.md#ajouter-la-bibliothèque-à-un-projet-existant).
+
+### Comment migrer
+
+1. Mettez à jour VueDsfr :
+
+   ```shell
+   npm install @gouvminint/vue-dsfr@latest
+   ```
+
+2. Si l'installation échoue avec un message mentionnant `.dsfr.yml` ou une version de CGU obsolète,
+   lancez :
+
+   ```shell
+   npm create @gouvfr/dsfr
+   ```
+
+   et validez les CGU à jour.
+
+3. Avec pnpm, si vous obtenez `ERR_PNPM_IGNORED_BUILDS: Ignored build scripts: @gouvfr/dsfr`, lancez :
+
+   ```shell
+   pnpm approve-builds @gouvfr/dsfr
+   ```
+
+4. Relancez l'installation.
+
+### CI/CD
+
+Pour éviter que vos pipelines échouent sur la validation interactive, utilisez la variable
+d'environnement `DSFR_ACCEPT_LICENSE=1` (après avoir vous-même validé les CGU au moins une fois côté
+développement), et pré-approuvez le build dans le `pnpm-workspace.yaml` **versionné** du projet (en
+l'ajoutant au fichier existant, sans l'écraser) :
+
+```yaml
+allowBuilds:
+  '@gouvfr/dsfr': true
+```
+
 ## Migration vers 8.x (depuis 7.x)
 
 Avant la v8, certaines fonctions qui ne devaient pas être dans le bundle final l’étaient : `vueDsfrComponentResolver` et `vueDsfrAutoimportPreset`.

--- a/docs/guide/pour-commencer.md
+++ b/docs/guide/pour-commencer.md
@@ -47,7 +47,46 @@ Et suivez les indications de l’assistant.
 
 ## Ajouter la bibliothèque à un projet existant
 
-### Installer la bibliothèque en tant que dépendance du projet
+::: warning DSFR ≥ 1.15 : validation des CGU obligatoire
+
+Depuis la version 1.15, `@gouvfr/dsfr` embarque un script de pré-installation qui **vérifie que vous avez
+accepté les Conditions Générales d'Utilisation (CGU) du DSFR**. VueDsfr distribue `@gouvfr/dsfr` en dépendance
+mais ne peut pas valider ces CGU à votre place — c'est à vous, développeur·se utilisant VueDsfr, de le faire.
+
+Sans cette validation, `npm install` / `pnpm install` / `yarn install` **échouera** avec un message d'erreur
+explicite plutôt que de s'installer silencieusement.
+
+:::
+
+### Étape 1 — Accepter les CGU du DSFR (une seule fois par projet)
+
+Avant d'ajouter VueDsfr à un projet (nouveau ou existant), initialisez/validez le DSFR avec son propre
+assistant :
+
+```shell
+npm create @gouvfr/dsfr
+# ou
+pnpm create @gouvfr/dsfr
+# ou
+yarn create @gouvfr/dsfr
+```
+
+Cet assistant vous présente les CGU et écrit un fichier `.dsfr.yml` à la racine de votre projet (contenant
+la version des CGU acceptée). **Ne supprimez pas ce fichier** : il est relu à chaque installation.
+
+::: info CI / intégration continue
+
+Pour un environnement non interactif (CI/CD), vous pouvez court-circuiter la validation avec la variable
+d'environnement `DSFR_ACCEPT_LICENSE=1` (à n'utiliser qu'après avoir vous-même validé les CGU au moins une
+fois en local) :
+
+```shell
+DSFR_ACCEPT_LICENSE=1 npm install
+```
+
+:::
+
+### Étape 2 — Installer la bibliothèque en tant que dépendance du projet
 
 Afin d'installer la bibliothèque, taper ces commandes dans votre console au sein du répertoire du projet :
 
@@ -60,6 +99,61 @@ npm install @gouvfr/dsfr @gouvminint/vue-dsfr
 `@gouvminint/vue-dsfr` utilise le CSS de `@gouvfr/dsfr`, c’est pourquoi il faut l’installer aussi.
 
 :::
+
+::: warning Spécifique à pnpm ≥ 10
+
+Depuis pnpm 10, les scripts d'installation (`preinstall`/`postinstall`) des dépendances sont **bloqués par
+défaut** pour des raisons de sécurité (supply-chain). Il faut explicitement autoriser celui de
+`@gouvfr/dsfr` :
+
+```shell
+pnpm add @gouvfr/dsfr @gouvminint/vue-dsfr --allow-build=@gouvfr/dsfr
+```
+
+Ou, si `@gouvfr/dsfr` est déjà présent dans votre lockfile et que pnpm affiche
+`ERR_PNPM_IGNORED_BUILDS` :
+
+```shell
+pnpm approve-builds @gouvfr/dsfr
+pnpm install
+```
+
+`pnpm approve-builds` ajoute (sans écraser le reste de votre configuration) une entrée dans le
+`pnpm-workspace.yaml` de **votre projet** :
+
+```yaml
+allowBuilds:
+  '@gouvfr/dsfr': true
+```
+
+Cette entrée reste valable pour toutes les futures versions de `@gouvfr/dsfr` : elle autorise
+l'exécution du script, mais **ne dispense pas** de la validation des CGU elle-même (voir Étape 1).
+
+⚠️ La commande `pnpm create @gouvfr/dsfr --allow-build=...` ne fonctionne **pas** : le flag
+`--allow-build` ne s'applique qu'au paquet exécuté via `dlx` (l'assistant `create-dsfr` lui-même), pas
+à l'installation qu'il déclenche ensuite dans le projet généré. Utilisez `pnpm approve-builds` une fois
+le projet créé.
+
+:::
+
+### Que se passe-t-il si les CGU changent lors d'une mise à jour ?
+
+Chaque version de `@gouvfr/dsfr` peut référencer une nouvelle version des CGU. Si vous montez de version
+(`@gouvfr/dsfr` ou `@gouvminint/vue-dsfr`) et que la version des CGU a changé, l'installation
+**échouera** avec un message du type :
+
+```text
+[UPDATE-1.0.1->1.1.0] La version des modalités d'utilisation acceptée (1.0.1) ne correspond pas
+à la dernière version des modalités d'utilisation (1.1.0). Lancez `pnpm create @gouvfr/dsfr`
+pour accepter les modalités d'utilisation à jour.
+```
+
+Il suffit de relancer l'assistant pour régénérer `.dsfr.yml` avec la nouvelle version acceptée, puis de
+relancer l'installation :
+
+```shell
+pnpm create @gouvfr/dsfr
+```
 
 ### ~~Utiliser la bibliothèque en tant que plugin~~
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,3 @@
 [build.environment]
 NODE_VERSION = "24"
+DSFR_ACCEPT_LICENSE = "1"

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "vue-router": "^5.0.3"
   },
   "dependencies": {
-    "@gouvfr/dsfr": "~1.14.4",
+    "@gouvfr/dsfr": "1.15.2",
     "focus-trap": "^8.2.2",
     "focus-trap-vue": "^4.1.0",
     "vue": "^3.5.41",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@gouvfr/dsfr':
-        specifier: ~1.14.4
-        version: 1.14.4
+        specifier: 1.15.2
+        version: 1.15.2
       focus-trap:
         specifier: ^8.2.2
         version: 8.2.2
@@ -1205,8 +1205,8 @@ packages:
       '@noble/hashes':
         optional: true
 
-  '@gouvfr/dsfr@1.14.4':
-    resolution: {integrity: sha512-Ca17apmTyAF2tMFwMcLwQN7fTlbfMFeyYSLUIUmjoSg1XVF4vDDkbvvKBpWJWaoTLDSFZBbvvHzcDyxw9wSkLA==}
+  '@gouvfr/dsfr@1.15.2':
+    resolution: {integrity: sha512-IrV/a/eV6KE06Az8Ky3wN2h0INka+ntk5UWuJg/T+ST7/tMUvIWC8fZi9azx+2YsqMFGgAkocIHxeVbPoLHAUQ==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   '@hapi/address@5.1.1':
@@ -8673,7 +8673,7 @@ snapshots:
 
   '@exodus/bytes@1.15.1': {}
 
-  '@gouvfr/dsfr@1.14.4': {}
+  '@gouvfr/dsfr@1.15.2': {}
 
   '@hapi/address@5.1.1':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 allowBuilds:
+  '@gouvfr/dsfr': true
   '@swc/core': true
   esbuild: true
   unrs-resolver: true

--- a/src/stories/fondamentaux/classes-utilitaires.mdx
+++ b/src/stories/fondamentaux/classes-utilitaires.mdx
@@ -4,6 +4,8 @@ import { Meta } from '@storybook/addon-docs/blocks'
 
 # Les classes utilitaires
 
+> **⚠️ DSFR 1.15** — Le rouge Marianne a été retiré des classes utilitaires de couleur, de fond et de bordure (`fr-text-title--red-marianne`, `fr-text-label--red-marianne`, `fr-text-inverted--red-marianne`, `fr-background-alt--red-marianne`, `fr-background-contrast--red-marianne`), leur utilisation n'étant pas autorisée. Les classes utilitaires d'artwork (`fr-artwork-*--red-marianne`) restent disponibles.
+
 ```css
 .fr-m-n8v,
 .fr-m-n4w {
@@ -2164,11 +2166,6 @@ import { Meta } from '@storybook/addon-docs/blocks'
   background-color: var(--background-alt-blue-france) !important;
 }
 
-.fr-background-alt--red-marianne {
-  --blend: var(--background-alt-red-marianne-blend) !important;
-  background-color: var(--background-alt-red-marianne) !important;
-}
-
 .fr-background-alt--green-tilleul-verveine {
   --blend: var(--background-alt-green-tilleul-verveine-blend) !important;
   background-color: var(--background-alt-green-tilleul-verveine) !important;
@@ -2262,11 +2259,6 @@ import { Meta } from '@storybook/addon-docs/blocks'
 .fr-background-contrast--blue-france {
   --blend: var(--background-contrast-blue-france-blend) !important;
   background-color: var(--background-contrast-blue-france) !important;
-}
-
-.fr-background-contrast--red-marianne {
-  --blend: var(--background-contrast-red-marianne-blend) !important;
-  background-color: var(--background-contrast-red-marianne) !important;
 }
 
 .fr-background-contrast--green-tilleul-verveine {
@@ -2427,20 +2419,12 @@ import { Meta } from '@storybook/addon-docs/blocks'
   color: var(--text-title-blue-france) !important;
 }
 
-.fr-text-title--red-marianne {
-  color: var(--text-title-red-marianne) !important;
-}
-
 .fr-text-label--grey {
   color: var(--text-label-grey) !important;
 }
 
 .fr-text-label--blue-france {
   color: var(--text-label-blue-france) !important;
-}
-
-.fr-text-label--red-marianne {
-  color: var(--text-label-red-marianne) !important;
 }
 
 .fr-text-label--green-tilleul-verveine {
@@ -2521,10 +2505,6 @@ import { Meta } from '@storybook/addon-docs/blocks'
 
 .fr-text-inverted--blue-france {
   color: var(--text-inverted-blue-france) !important;
-}
-
-.fr-text-inverted--red-marianne {
-  color: var(--text-inverted-red-marianne) !important;
 }
 
 .fr-text-inverted--info {


### PR DESCRIPTION
## Résumé
- Met à jour la dépendance `@gouvfr/dsfr` de `~1.14.4` vers `1.15.2` (version épinglée)
- Ajoute `'@gouvfr/dsfr': true` dans `allowBuilds` de `pnpm-workspace.yaml` pour autoriser le script d'installation de `@gouvfr/dsfr` avec pnpm ≥ 10
- Ignore le fichier local `.dsfr.yml` (marqueur d'acceptation des CGU) dans `.gitignore`
- Ajout de la variable d'environnement DSFR_ACCEPT_LICENSE=1 dans la CI/CD
- Documente dans le guide « Pour commencer » la validation obligatoire des CGU du DSFR (assistant `create @gouvfr/dsfr`, cas pnpm avec `pnpm approve-builds`, gestion des changements de CGU lors des mises à jour)
- Ajoute une section « Migration vers 9.x (DSFR 1.15+) » au guide de migration
- Ajoute un avertissement avec lien vers le guide détaillé dans le `README.md`

⚠️ Breaking change : les projets utilisant VueDsfr devront valider les CGU du DSFR (via `pnpm create @gouvfr/dsfr` ou équivalent) avant de pouvoir installer ou mettre à jour la bibliothèque.

## Vérification
- Documentation relue et corrigée (lint markdown : erreurs `MD031` introduites corrigées ; aucune ancre cassée entre `migrations.md` et `pour-commencer.md`)
- Tests : `pnpm test:unit`, `pnpm lint`, `pnpm build`

closes #1351




~~❌  : oubli variable d'environnement DSFR_ACCEPT_LICENSE=1~~