### PR TITLE
Ajoute la prop titleTag à DsfrModal pour gérer le niveau de titre

### DIFF
--- a/src/components/DsfrModal/DsfrModal.md
+++ b/src/components/DsfrModal/DsfrModal.md
@@ -28,6 +28,7 @@ Elle se compose des éléments suivants :
 | Propriété            | Type                           | Description                                                                                                    | Valeur par défaut                                              | Obligatoire  |
 |----------------------|--------------------------------|----------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------|--------------|
 | `title`              | `string`                       | Titre de la modale.                                                                                            |                                                                | ✅            |
+| `titleTag`           | `'h1' \| 'h2' \| 'h3' \| 'h4' \| 'h5' \| 'h6'` | Balise HTML du titre de la modale.                                                             | `'h1'`                                                         |              |
 | `modalId`            | `string`                       | Identifiant unique pour la modale.                                                                             | `useRandomId('modal', 'dialog')`                               |              |
 | `opened`             | `boolean`                      | Indique si la modale est ouverte.                                                                              | `false`                                                        |              |
 | `actions`            | `DsfrButtonProps[]`            | Liste des boutons d'action pour le pied de page de la modale.                                                  | `[]`                                                           |              |
@@ -40,6 +41,16 @@ Elle se compose des éléments suivants :
 | `disableOutsideInteraction` | `boolean`              | Désactive la fermeture de la modale au clic en dehors de son contenu (overlay).                               | `false`                                                        |              |
 
 Lorsque `disableOutsideInteraction` vaut `true`, la modale ne se ferme pas lors d'un clic à l'extérieur de `.fr-modal__body`. La fermeture reste possible via le bouton de fermeture, les actions de votre interface, ou `Escape` (sauf comportement spécifique applicatif).
+
+::: tip ♿ Accessibilité — niveau de titre de la modale
+
+La [documentation DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/modale/accessibilite-de-la-modale) indique que la modale doit avoir un titre de niveau `h1` à `h6` (jamais une balise `<p>`, qui n'a pas de valeur de titre pour les technologies d'assistance).
+
+Le niveau par défaut est `h1` : la modale étant considérée comme hors du flux normal de la page (elle capte l'intégralité de l'attention), ce choix garantit une accessibilité correcte même si vous ne personnalisez pas `titleTag`.
+
+Si vous préférez considérer la modale comme faisant partie du flux du document, adaptez `titleTag` au niveau de titre cohérent avec la hiérarchie de votre page (par exemple `h2` si la modale est ouverte depuis une section de niveau `h1`).
+
+:::
 
 ## 📡Événements
 

--- a/src/components/DsfrModal/DsfrModal.spec.ts
+++ b/src/components/DsfrModal/DsfrModal.spec.ts
@@ -173,6 +173,45 @@ describe('DsfrModal', () => { // Skipped because of this issue: https://github.c
     expect(heading.text()).toContain(title)
   })
 
+  it('should render the title as an h1 by default', async () => {
+    const title = 'Titre de la modale'
+    const modalId = 'test-modal'
+
+    const wrapper = mount(DsfrModal, {
+      props: {
+        opened: true,
+        title,
+        modalId,
+      },
+      slots: {
+        default: 'contenu',
+      },
+    })
+
+    const heading = wrapper.find(`#${modalId}`)
+    expect(heading.element.tagName).toBe('H1')
+  })
+
+  it('should render the title with the tag given by titleTag', async () => {
+    const title = 'Titre de la modale'
+    const modalId = 'test-modal'
+
+    const wrapper = mount(DsfrModal, {
+      props: {
+        opened: true,
+        title,
+        titleTag: 'h2',
+        modalId,
+      },
+      slots: {
+        default: 'contenu',
+      },
+    })
+
+    const heading = wrapper.find(`#${modalId}`)
+    expect(heading.element.tagName).toBe('H2')
+  })
+
   it('should render the description wrapper with the correct id for aria-describedby', async () => {
     const content = 'Description de la modale'
     const modalId = 'test-modal'

--- a/src/components/DsfrModal/DsfrModal.stories.ts
+++ b/src/components/DsfrModal/DsfrModal.stories.ts
@@ -53,6 +53,12 @@ const meta = {
       control: 'text',
       description: 'Titre de la modale',
     },
+    titleTag: {
+      control: 'radio',
+      options: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
+      description:
+        'Balise de titre à utiliser pour le titre de la modale. À adapter selon la position de la modale dans le flux du document ; conservez un vrai niveau de titre (jamais `p`) pour l’accessibilité',
+    },
     icon: {
       control: 'text',
       description: 'Icone à afficher au début du titre de la modale',
@@ -130,6 +136,7 @@ export const ModaleAvecActions: Story = {
         :is-alert="args.isAlert"
         :icon="args.icon"
         :title="args.title"
+        :title-tag="args.titleTag"
         :origin="modalOrigin"
         :size="args.size"
         :close-button-label="args.closeButtonLabel"
@@ -144,6 +151,7 @@ export const ModaleAvecActions: Story = {
   args: {
     opened: false,
     title: 'Titre de la modale',
+    titleTag: 'h1',
     isAlert: false,
     icon: 'ri-checkbox-circle-line',
     size: 'md',
@@ -223,6 +231,7 @@ export const ModaleSansPiedDePage: Story = {
         :is-alert="args.isAlert"
         :icon="args.icon"
         :title="args.title"
+        :title-tag="args.titleTag"
         :origin="modalOrigin"
         :size="args.size"
         :close-button-label="args.closeButtonLabel"
@@ -237,6 +246,7 @@ export const ModaleSansPiedDePage: Story = {
   args: {
     opened: false,
     title: 'Titre de la modale',
+    titleTag: 'h1',
     isAlert: false,
     icon: 'ri-checkbox-circle-line',
     size: 'md',
@@ -278,6 +288,7 @@ export const ModaleAvecFooterPersonnalise: Story = {
         :is-alert="args.isAlert"
         :icon="args.icon"
         :title="args.title"
+        :title-tag="args.titleTag"
         :origin="modalOrigin"
         :size="args.size"
         :close-button-label="args.closeButtonLabel"
@@ -295,6 +306,7 @@ export const ModaleAvecFooterPersonnalise: Story = {
   args: {
     opened: false,
     title: 'Titre de la modale',
+    titleTag: 'h1',
     isAlert: false,
     icon: 'ri-checkbox-circle-line',
     size: 'md',

--- a/src/components/DsfrModal/DsfrModal.types.ts
+++ b/src/components/DsfrModal/DsfrModal.types.ts
@@ -1,3 +1,4 @@
+import type { TitleTag } from '../../common-types'
 import type { DsfrButtonProps } from '../DsfrButton/DsfrButton.types'
 
 export type DsfrModalProps = {
@@ -7,6 +8,7 @@ export type DsfrModalProps = {
   isAlert?: boolean
   origin?: { focus: () => void }
   title: string
+  titleTag?: TitleTag
   icon?: string
   size?: 'sm' | 'md' | 'lg' | 'xl'
   closeButtonLabel?: string

--- a/src/components/DsfrModal/DsfrModal.vue
+++ b/src/components/DsfrModal/DsfrModal.vue
@@ -17,6 +17,7 @@ const props = withDefaults(defineProps<DsfrModalProps>(), {
   origin: () => ({ focus () {} }),
   icon: undefined,
   size: 'md',
+  titleTag: 'h1',
   closeButtonLabel: 'Fermer',
   closeButtonTitle: 'Fermer la fenêtre modale',
 })
@@ -203,7 +204,8 @@ const iconProps = computed(() => dsfrIcon.value
                 ref="modalContent"
                 class="fr-modal__content"
               >
-                <h1
+                <component
+                  :is="titleTag"
                   :id="modalId"
                   class="fr-modal__title"
                 >
@@ -219,7 +221,7 @@ const iconProps = computed(() => dsfrIcon.value
                     />
                   </span>
                   {{ title }}
-                </h1>
+                </component>
                 <!-- @slot Slot par défaut pour le contenu de la liste. Sera dans `<ul class="fr-modal__title">` -->
                 <div :id="`${modalId}-description`">
                   <slot />


### PR DESCRIPTION
## Résumé
- Le titre de `DsfrModal` était codé en dur en `h1`, alors que la documentation DSFR indique qu'il doit être une balise `h1` à `h6` selon la position de la modale dans le flux du document (jamais une balise `p`, sans valeur de titre pour les technologies d'assistance)
- Ajout de la prop `titleTag?: TitleTag` (réutilise le type partagé `TitleTag` de `src/common-types.ts`, déjà utilisé par `DsfrCallout`), avec la valeur par défaut `'h1'` pour garantir une accessibilité correcte sans personnalisation
- Mise à jour des stories, de la documentation (tableau des props + encart d'accessibilité expliquant le choix du niveau de titre) et ajout de tests unitaires (titre par défaut `h1`, titre personnalisé `h2`)

## Vérification
- `pnpm exec vitest run src/components/DsfrModal` : 14 tests passent (2 nouveaux cas ajoutés)
- `pnpm lint` : aucune erreur, aucun warning sur les fichiers modifiés
- `pnpm exec vue-tsc --noEmit` : aucune erreur de typage sur les fichiers modifiés
- `pnpm check-exports` : OK

closes #1353
