### PR TITLE
Corrige la duplication de la barre de recherche au passage en desktop

### DIFF
--- a/src/components/DsfrHeader/DsfrHeader.spec.ts
+++ b/src/components/DsfrHeader/DsfrHeader.spec.ts
@@ -1,5 +1,5 @@
 import { fireEvent } from '@testing-library/dom'
-import { render } from '@testing-library/vue'
+import { render, waitFor } from '@testing-library/vue'
 import { createRouter, createWebHistory } from 'vue-router'
 
 import VIcon from '../VIcon/VIcon.vue'
@@ -133,5 +133,52 @@ describe.skip('DsfrHeader', () => { // Skipped because of this issue: https://gi
 
     // Then
     expect(betaBadge).toHaveClass('fr-badge')
+  })
+})
+
+describe('DsfrHeader - bascule du mode mobile vers le mode desktop', () => {
+  it('ne laisse qu’une seule barre de recherche après le passage en desktop', async () => {
+    // Given
+    const matchMediaSpy = vi.spyOn(window, 'matchMedia')
+      .mockImplementation(() => ({ matches: false }) as MediaQueryList)
+
+    try {
+      const { container, getByTitle } = render(DsfrHeader, {
+        global: {
+          plugins: [router],
+          components: {
+            VIcon,
+          },
+          stubs: {
+            FocusTrap: {
+              template: '<div><slot /></div>',
+            },
+          },
+        },
+        props: {
+          serviceTitle: 'Nom du service',
+          showSearch: true,
+        },
+      })
+
+      await router.isReady()
+
+      // When
+      await fireEvent.click(getByTitle('Recherche'))
+
+      // Then
+      expect(container.querySelectorAll('.fr-search-bar')).toHaveLength(2)
+
+      // When
+      matchMediaSpy.mockImplementation(() => ({ matches: true }) as MediaQueryList)
+      window.dispatchEvent(new Event('resize'))
+
+      // Then
+      await waitFor(() => {
+        expect(container.querySelectorAll('.fr-search-bar')).toHaveLength(1)
+      })
+    } finally {
+      matchMediaSpy.mockRestore()
+    }
   })
 })

--- a/src/components/DsfrHeader/DsfrHeader.vue
+++ b/src/components/DsfrHeader/DsfrHeader.vue
@@ -76,11 +76,33 @@ const onKeyDown = (e: KeyboardEvent) => {
   }
 }
 
+// Keep this value aligned with DSFR breakpoints.
+// @gouvfr/dsfr/src/dsfr/core/script/api/modules/register/breakpoints.js
+const lgBreakpointQuery = '(min-width: 62em)'
+
+const isDesktopViewport = () => {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false
+  }
+  return window.matchMedia(lgBreakpointQuery).matches
+}
+
+const closeSearchModalOnDesktop = () => {
+  if (!searchModalOpened.value || !isDesktopViewport()) {
+    return
+  }
+  modalOpened.value = false
+  menuOpened.value = false
+  searchModalOpened.value = false
+}
+
 onMounted(() => {
   document.addEventListener('keydown', onKeyDown)
+  window.addEventListener('resize', closeSearchModalOnDesktop)
 })
 onUnmounted(() => {
   document.removeEventListener('keydown', onKeyDown)
+  window.removeEventListener('resize', closeSearchModalOnDesktop)
 })
 
 const showMenu = () => {


### PR DESCRIPTION
## Résumé
- Ouvrir la recherche en affichage mobile puis élargir la fenêtre jusqu'au mode desktop sans refermer la modale laissait deux barres de recherche dans le DOM, partageant le même identifiant
- `DsfrHeader` referme désormais la modale de recherche dès que la rupture `lg` (62em) est franchie, via un écouteur `resize` posé et retiré aux côtés de l'écouteur `keydown` existant
- La fermeture ne passe pas par `hideModal`, qui redonnerait le focus à `#button-menu` alors que ce bouton n'est pas affiché en desktop
- La rupture est lue avec `window.matchMedia`, en reprenant la garde et le renvoi aux ruptures du DSFR déjà employés par `DsfrDataTable`
- Le stub `window.matchMedia` de `tests/unit/vitest-setup.ts` n'exposant que `matches`, le composant interroge la media query plutôt que de s'abonner à ses événements

## Vérification
- `pnpm vitest run src/components/DsfrHeader/DsfrHeader.spec.ts` : le nouveau test échoue avant le correctif (deux barres après la bascule) et passe après
- `pnpm test:unit` : 441 tests passés ; les deux échecs restants sont des dépassements du `testTimeout` de 2000 ms, reproduits sur `develop` sans le correctif et portant sur d'autres fichiers
- `npx eslint src/components/DsfrHeader/DsfrHeader.vue src/components/DsfrHeader/DsfrHeader.spec.ts` : aucun problème signalé
- Sur la deploy preview, après ouverture de la recherche en mobile puis élargissement en desktop : une seule barre, contre deux sur https://demo.vue-ds.fr/
- Le test est ajouté dans un `describe` distinct, la suite existante de `DsfrHeader` étant `describe.skip` ; `FocusTrap` y est bouchonné

closes #1098
